### PR TITLE
update jb contributor link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Welcome to the `jupyter-book` repository! We're excited you're here and want to 
 The Jupyter Book project is run by a community of people like you, we'd love to have you
 help out!
 
-Please take a look at the [Jupyter Book contributor guide](https://jupyterbook.org/contributing)
+Please take a look at the [Jupyter Book contributor guide](https://jupyterbook.org/advanced/contributing.html)
 which steps you through the codebase and how to contribute to this project.
 If you have any questions that aren't answered there, please let us know by
 [opening an issue][link_issues]!


### PR DESCRIPTION
The current [jb contributor link](https://jupyterbook.org/contributing) is not working. This PR updates it to https://jupyterbook.org/advanced/contributing.html.