### PR TITLE
update latexpdf to pdflatex in the documentation

### DIFF
--- a/docs/advanced/pdf.md
+++ b/docs/advanced/pdf.md
@@ -83,13 +83,13 @@ For `Windows` please install [texlive](https://www.tug.org/texlive/windows.html)
 To build a single PDF using LaTeX, use the following command:
 
 ```
-jupyter-book build mybookname/ --builder latexpdf
+jupyter-book build mybookname/ --builder pdflatex
 ```
 
 or
 
 ```
-jb build mybookname/ --builder latexpdf
+jb build mybookname/ --builder pdflatex
 ```
 
 ```{note}


### PR DESCRIPTION
The current documentation [here](https://jupyterbook.org/advanced/pdf.html) tells the user to build a PDF using LaTeX through `--builder latexpdf`. The value for `--build` must instead be `pdflatex`. This PR updates the documentation to reflect this.