### PR TITLE
Add modules needed to build the example book to the instructions.

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -56,7 +56,7 @@ You can build this book locally on the command line via the following steps:
 2. Install the Python libraries needed to run the code in this particular example:
 
     ```
-    conda install numpy matplotlib
+    conda install numpy scipy matplotlib sympy pandas
     ```
 
 3. Install the pre-release for Jupyter Book
@@ -75,6 +75,7 @@ You can build this book locally on the command line via the following steps:
 
     ```
     cd quantecon-mini-example
+    jupyter-book toc mini_book/docs
     jupyter-book build mini_book/docs
     ```
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -56,7 +56,7 @@ You can build this book locally on the command line via the following steps:
 2. Install the Python libraries needed to run the code in this particular example:
 
     ```
-    conda install numpy scipy matplotlib sympy pandas
+    conda env create -f environment.yml
     ```
 
 3. Install the pre-release for Jupyter Book
@@ -75,8 +75,7 @@ You can build this book locally on the command line via the following steps:
 
     ```
     cd quantecon-mini-example
-    jupyter-book toc mini_book/docs
-    jupyter-book build mini_book/docs
+    jupyter-book build mini_book
     ```
 
 6. View the result through a browser --- try (with, say, firefox)


### PR DESCRIPTION
The `jupyter-book build` step evaluates cells in the book, which includes imports for SciPy, SymPy, and Pandas, not just NumPy and Matplotlib.

Also, a `toc` needs to be created before the build step. (There's an error message to that effect.)

Finally, once the example is built, the static images don't load—it seems they haven't been copied from `mini_book/_static` to `mini_book/docs/_build/html/_static`. This PR doesn't fix that problem, just the above two.