### PR TITLE
explicitly giving jupyter book install version

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -62,7 +62,7 @@ You can build this book locally on the command line via the following steps:
 3. Install the pre-release for Jupyter Book
 
     ```
-    pip install -U jupyter-book --pre
+    pip install -U jupyter-book>=0.7.0b
     ```
 
 4. Clone the repository containing the source files
@@ -140,7 +140,7 @@ Install the pre-release of Jupyter Book from PyPI. This version of
 Jupyter Book may change a bit, but is ready for use.
 
 ```
-pip install -U jupyter-book --pre
+pip install -U jupyter-book>=0.7.0b
 ```
 
 ## Develop

--- a/docs/publish/gh-pages.md
+++ b/docs/publish/gh-pages.md
@@ -70,7 +70,14 @@ an action that does the following things:
 * Uses a `gh-pages` action to upload that HTML to your `gh-pages` branch.
 
 For reference, [here is a sample repository](https://github.com/executablebooks/github-action-demo)
-that builds a book with GitHub Actions. Here is a simple YAML configuration
+that builds a book with GitHub Actions.
+
+```{note}
+Ensure that Jupyter Book's version in your `requirements.txt` file is at least
+`0.7.0b`. This line will do the trick: `jupyter-book>=0.7.0b`.
+```
+
+Here is a simple YAML configuration
 for a github action that will publish your book to a `gh-pages` branch.
 
 ```yaml
@@ -98,10 +105,6 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements.txt
-    - name: Install Jupyter Book
-      run: |
-        pip install -U --pre jupyter-book
-
 
     # Build the book
     - name: Build the book

--- a/docs/publish/netlify.md
+++ b/docs/publish/netlify.md
@@ -60,7 +60,12 @@ Assuming that your book's dependencies are in a `requirements.txt` file,
 **put the following command in the *Build command* section**:
 
 ```bash
-pip install --pre jupyter-book && pip install -r requirements.txt && jupyter-book build .
+pip install -r requirements.txt && jupyter-book build .
+```
+
+```{note}
+Ensure that Jupyter Book's version in your `requirements.txt` file is at least
+`0.7.0b`. This line will do the trick: `jupyter-book>=0.7.0b`.
 ```
 
 Finally, the *Publish directory* should be `_build/html`.

--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -12,7 +12,7 @@ The Jupyter-Book CLI allows you to build and control your
 Jupyter Book. You can install it via pip with the following command:
 
 ```bash
-pip install -U jupyter-book --pre
+pip install -U jupyter-book>=0.7.0b
 ```
 
 ## The book building process


### PR DESCRIPTION
cc @jpivarski - I believe that this will explicitly install the pre-release of only jupyter book, and not any other dependency.

closes #534 (I think that issue is being tracked in the MyST-NB repository)