### PR TITLE
Corrects info on bibliography in separate file

### DIFF
--- a/docs/content/citations.md
+++ b/docs/content/citations.md
@@ -86,13 +86,8 @@ When your book is built, the bibliography and citations will now be included.
 
 `````{warning}
 If you are adding a bibliography to a *different* page from your references, then
-make sure you add the `:all:` flag when creating the bibliography, like so:
-
-````
-```{bibliography}
-:all:
-```
-````
+you may need to ensure that page is processed last, which Sphinx does alphabetically.
+For example, name the file `zreferences.rst`.
 
 See [this `sphinxcontrib-bibtex` section](https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#unresolved-citations-across-documents)
 for more information.


### PR DESCRIPTION
Adding the `:all:` directive puts all references in the `.bib` file, but it doesn't actually ensure that the citations on other pages are properly captured. Instead, you have to make sure the (separate) file with the bibliography is processed last.