### PR TITLE
Fix of broken references in docs

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -82,13 +82,13 @@ You can build this book locally on the command line via the following steps:
 
 
     ```
-    firefox mini_book/docs/_build/html/index.html
+    firefox mini_book/_build/html/index.html
     ```
 
     or
 
     ```
-    cd mini_book/docs/_build/html
+    cd mini_book/_build/html
     python -m http.server
     ```
 


### PR DESCRIPTION
Off topic for PR that simply fixes a broken reference, but I'm a bit confused about the `Build the demo book` section.

What was the `environment.yaml` for in step 1? Was it for quantecon-mini-example, or jupyter-book's environment.yaml?