### PR TITLE
Fix broken references in docs

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -53,22 +53,22 @@ You can build this book locally on the command line via the following steps:
 
 1. Ensure you have a recent version of [Anaconda Python](https://www.anaconda.com/distribution/) installed.
 
-2. Install the Python libraries needed to run the code in this particular example:
-
-    ```
-    conda env create -f environment.yml
-    ```
-
-3. Install the pre-release for Jupyter Book
+2. Install the pre-release for Jupyter Book
 
     ```
     pip install -U jupyter-book>=0.7.0b
     ```
 
-4. Clone the repository containing the source files
+3. Clone the repository containing the source files
 
     ```
     git clone https://github.com/executablebooks/quantecon-mini-example
+    ```
+
+4. Install the Python libraries needed to run the code in this particular example:
+
+    ```
+    conda env create -f environment.yml
     ```
 
 5. Run Jupyter Book over the source files

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -82,13 +82,13 @@ You can build this book locally on the command line via the following steps:
 
 
     ```
-    firefox mini_book/docs/_build/html/index.html
+    firefox mini_book/_build/html/index.html
     ```
 
     or
 
     ```
-    cd mini_book/docs/_build/html
+    cd mini_book/_build/html
     python -m http.server
     ```
 


### PR DESCRIPTION
## PR - microfix

## Question about this section in the docs

I'm confused about the `environment.yaml` in the `Build the demo book` section.

There are too many demo books that I've found, so it isn't obvious what is the demo book even though one was mentioned explicitly above hehe. The instructions started with installing an environment.yaml file, and I was ended up cloning the quantecon-mini-example first and then installing that environment.yaml, then I find that in step 4 I was meant to clone the quantecon-mini-example so the environment.yaml in step 1 must have been relating to the jupyter-book repo I guess.

Should the first step be to clone the jupyter-book repo?