### PR TITLE
[BUG] Added a returncode for make all-pdf

### DIFF
--- a/jupyter_book/commands/__init__.py
+++ b/jupyter_book/commands/__init__.py
@@ -172,7 +172,7 @@ def build(path_book, path_output, config, toc, warningiserror, builder):
                 with cd(OUTPUT_PATH):
                     output = subprocess.run([makecmd, "all-pdf"])
                     if output.returncode != 0:
-                        exit(output.returncode)
+                        _error("Error: Failed to build pdf")
                 _message_box(
                     f"""\
                 A PDF of your book can be found at:

--- a/jupyter_book/commands/__init__.py
+++ b/jupyter_book/commands/__init__.py
@@ -172,7 +172,7 @@ def build(path_book, path_output, config, toc, warningiserror, builder):
                 with cd(OUTPUT_PATH):
                     output = subprocess.run([makecmd, "all-pdf"])
                     if output.returncode != 0:
-                        return output.returncode
+                        exit(output.returncode)
                 _message_box(
                     f"""\
                 A PDF of your book can be found at:

--- a/jupyter_book/commands/__init__.py
+++ b/jupyter_book/commands/__init__.py
@@ -173,6 +173,7 @@ def build(path_book, path_output, config, toc, warningiserror, builder):
                     output = subprocess.run([makecmd, "all-pdf"])
                     if output.returncode != 0:
                         _error("Error: Failed to build pdf")
+                        return output.returncode
                 _message_box(
                     f"""\
                 A PDF of your book can be found at:

--- a/jupyter_book/commands/__init__.py
+++ b/jupyter_book/commands/__init__.py
@@ -170,7 +170,9 @@ def build(path_book, path_output, config, toc, warningiserror, builder):
                 makecmd = os.environ.get("MAKE", "make")
             try:
                 with cd(OUTPUT_PATH):
-                    subprocess.run([makecmd, "all-pdf"])
+                    output = subprocess.run([makecmd, "all-pdf"])
+                    if output.returncode != 0:
+                        return output.returncode
                 _message_box(
                     f"""\
                 A PDF of your book can be found at:


### PR DESCRIPTION
check for the return code and return the error code when `mak all-pdf` errors

fixes https://github.com/executablebooks/jupyter-book/issues/551

This will make the build fail, when pdflatex build errors.

cc: @choldgraf @mmcky 

@choldgraf , any other requirements from that issue?