### PR TITLE
update vscode myst markdown extension url

### DIFF
--- a/docs/content/myst.md
+++ b/docs/content/myst.md
@@ -164,5 +164,5 @@ Jupytext [supports the MyST markdown format](https://jupytext.readthedocs.io/en/
 ### VSCode
 
 If editing the markdown files using VS Code, the
-[vscode MyST markdown extension](https://marketplace.visualstudio.com/items?itemName=executablebooks.myst-highlight)
+[vscode MyST markdown extension](https://marketplace.visualstudio.com/items?itemName=ExecutableBookProject.myst-highlight)
 provides syntax highlighting and other features.


### PR DESCRIPTION
This PR updates the vscode MyST markdown extension url. The current url takes the user to a `404` error page.