### PR TITLE
add build to test_clean method prior to build  --builder pdflatex

### DIFF
--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -64,11 +64,14 @@ def test_clean_html(tmpdir):
 
 def test_clean_latex(tmpdir):
     path = path_books.joinpath("clean_cache")
-    build_path = path.joinpath("_build")
-    run(f"jb build {path} --builder pdflatex".split(), check=True)
+    run(f"jb build {path}".split())
 
+    build_path = path.joinpath("_build")
     # Ensure _build exists
     assert build_path.exists()
+
+    run(f"jb build {path} --builder pdflatex".split(), check=True)
+
     # Ensure _build/html exists
     assert build_path.joinpath("latex").exists()
 
@@ -85,6 +88,7 @@ def test_clean_latex(tmpdir):
 def test_clean_html_latex(tmpdir):
     path = path_books.joinpath("clean_cache")
     build_path = path.joinpath("_build")
+
     run(f"jb build {path} --builder pdflatex".split(), check=True)
 
     # Ensure _build exists
@@ -95,7 +99,6 @@ def test_clean_html_latex(tmpdir):
     # Ensure _build exists
     assert build_path.exists()
 
-    run(f"jb build {path} --builder html".split())
     # Ensure _build/html exists
     assert build_path.joinpath("html").exists()
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -94,7 +94,6 @@ def test_clean_html_latex(tmpdir):
 
     # Ensure _build exists
     assert build_path.exists()
-
     os.mkdir(os.path.join(build_path, "latex"))
 
     # Ensure _build/html exists

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -70,7 +70,7 @@ def test_clean_latex(tmpdir):
     # Ensure _build exists
     assert build_path.exists()
 
-    run(f"jb build {path} --builder pdflatex".split(), check=True)
+    run(f"jb build {path} --builder pdflatex".split())
 
     # Ensure _build/html exists
     assert build_path.joinpath("latex").exists()
@@ -89,7 +89,7 @@ def test_clean_html_latex(tmpdir):
     path = path_books.joinpath("clean_cache")
     build_path = path.joinpath("_build")
 
-    run(f"jb build {path} --builder pdflatex".split(), check=True)
+    run(f"jb build {path} --builder pdflatex".split())
 
     # Ensure _build exists
     assert build_path.exists()

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from subprocess import run, PIPE
 import pytest
+import os
 
 
 path_tests = Path(__file__).parent.resolve()
@@ -70,7 +71,7 @@ def test_clean_latex(tmpdir):
     # Ensure _build exists
     assert build_path.exists()
 
-    run(f"jb build {path} --builder pdflatex".split())
+    os.mkdir(os.path.join(build_path, "latex"))
 
     # Ensure _build/html exists
     assert build_path.joinpath("latex").exists()
@@ -87,17 +88,17 @@ def test_clean_latex(tmpdir):
 
 def test_clean_html_latex(tmpdir):
     path = path_books.joinpath("clean_cache")
+    run(f"jb build {path}".split())
+
     build_path = path.joinpath("_build")
 
-    run(f"jb build {path} --builder pdflatex".split())
-
     # Ensure _build exists
     assert build_path.exists()
+
+    os.mkdir(os.path.join(build_path, "latex"))
+
     # Ensure _build/html exists
     assert build_path.joinpath("latex").exists()
-
-    # Ensure _build exists
-    assert build_path.exists()
 
     # Ensure _build/html exists
     assert build_path.joinpath("html").exists()


### PR DESCRIPTION
This PR addresses the failed execution of `test_clean.py` mentioned in #556. I've removed `check=True` which is throwing an error during `build --builder pdflatex`.