### PR TITLE
add ticks to execute_notebooks: off in docs

### DIFF
--- a/docs/content/execute.md
+++ b/docs/content/execute.md
@@ -44,7 +44,7 @@ above configuration value to:
 
 ```yaml
 execute:
-  execute_notebooks: off
+  execute_notebooks: 'off'
 ```
 
 **To exclude certain file patterns from execution**, use the following


### PR DESCRIPTION
cause otherwise it won't work.