### PR TITLE
DOC: A few documentation fix-ups

### DIFF
--- a/docs/advanced/pdf.md
+++ b/docs/advanced/pdf.md
@@ -10,7 +10,7 @@ PDF building is experimental, and may change or have bugs.
 There are two approaches to building PDF files:
 
 ```{contents}
-:depth: 1
+:depth: 2
 ```
 
 ## Build a PDF from your book HTML

--- a/docs/advanced/sphinx.md
+++ b/docs/advanced/sphinx.md
@@ -94,7 +94,7 @@ Simple is better than complex. 😵
 ```
 ````
 
-## Manually sphinx configuration
+## Manual sphinx configuration
 
 You may also directly override the key-value pairs that Sphinx normally has
 you configure in `conf.py`. To do so, use the following section of `_config.yml`:

--- a/docs/content/citations.md
+++ b/docs/content/citations.md
@@ -117,7 +117,7 @@ to label:
 
 For example, we've added the following label above the header for this section:
 
-```
+```md
 (labels-and-refs)=
 ## Cross-references and labels
 ```

--- a/docs/content/citations.md
+++ b/docs/content/citations.md
@@ -119,7 +119,7 @@ For example, we've added the following label above the header for this section:
 
 ```
 (labels-and-refs)=
-## Labels and cross-references
+## Cross-references and labels
 ```
 
 You can insert cross-references to labels in your content with the following

--- a/docs/content/myst.md
+++ b/docs/content/myst.md
@@ -21,6 +21,7 @@ relates to Jupyter Book. You can
 find much more information about this flavor of markdown at
 [The Myst Parser documentation][myst-parser].
 
+[myst-parser]: https://myst-parser.readthedocs.io/en/latest/
 
 ## Directives and roles
 


### PR DESCRIPTION
A few fixes to documentation from another read-through to catch up with all the exciting features. All very minor text/formatting changes, though the change in d46d7d9 warrants a closer look:

The main issue there is that a literal block (with no language specifier/info string) in [content/citations.md](https://raw.githubusercontent.com/executablebooks/jupyter-book/master/docs/content/citations.md) is using Python syntax highlighting, i.e. this:

````
```
(labels-and-refs)=
## Labels and cross-references
```
````
Renders [with Python syntax highlighting](https://jupyterbook.org/content/citations.html#cross-references-and-labels)

 I would've expected the fenced section to have no syntax highlighting at all - in fact, this is the case for some of the fenced sections demonstrating the `{cite}` role further up in the same document. I'm not sure whether this behavior is unexpected, but it did surprise me.