### PR TITLE
ENH: Modify execute option for jb page command.

### DIFF
--- a/docs/start/build.md
+++ b/docs/start/build.md
@@ -54,7 +54,7 @@ jupyter-book page path/to/mypage.ipynb
 ```
 
 This will execute your content and output the proper HTML in a
-`_build/html` folder. 
+`_build/html` folder.
 If you'd like to generate HTML for a page *without* executing any
 code cells, you can use the `--no-execute` flag:
 

--- a/docs/start/build.md
+++ b/docs/start/build.md
@@ -54,7 +54,15 @@ jupyter-book page path/to/mypage.ipynb
 ```
 
 This will execute your content and output the proper HTML in a
-`_build/html` folder. Your page will be called `mypage.html`. This will work
+`_build/html` folder. 
+If you'd like to generate HTML for a page *without* executing any
+code cells, you can use the `--no-execute` flag:
+
+```
+jupyter-book page --no-execute path/to/mypage.ipynb
+```
+
+Your page will be called `mypage.html`. This will work
 for any {doc}`content source file <../content-types/index>`) that is supported by Jupyter Book.
 
 ## Page caching

--- a/jupyter_book/__init__.py
+++ b/jupyter_book/__init__.py
@@ -31,6 +31,9 @@ def setup(app):
     # configuration for YAML metadata
     app.add_config_value("yaml_config_path", "", "html")
 
+    # configuration object for CLI overrides
+    app.add_config_value("cli_overrides", {}, "env")
+
     app.connect("config-inited", add_yaml_config)
     app.connect("config-inited", add_static_files)
 

--- a/jupyter_book/commands/__init__.py
+++ b/jupyter_book/commands/__init__.py
@@ -210,10 +210,10 @@ def page(path_page, path_output, config, execute):
     PAGE_NAME = PATH_PAGE.with_suffix("").name
     if config is None:
         config = ""
-    if not execute:
-        execute = "off"
-    else:
+    if execute:
         execute = "force"
+    else:
+        execute = "off"
 
     OUTPUT_PATH = path_output if path_output is not None else PATH_PAGE_FOLDER
     OUTPUT_PATH = Path(OUTPUT_PATH).joinpath("_build/html")

--- a/jupyter_book/commands/__init__.py
+++ b/jupyter_book/commands/__init__.py
@@ -199,7 +199,8 @@ def build(path_book, path_output, config, toc, warningiserror, builder):
 @click.argument("path-page")
 @click.option("--path-output", default=None, help="Path to the output artifacts")
 @click.option("--config", default=None, help="Path to the YAML configuration file")
-@click.option("--execute", default=None, help="Whether to execute the notebook first")
+@click.option("--execute/--no-execute", default=True,
+              help="Whether to execute the notebook. Default is --execute")
 def page(path_page, path_output, config, execute):
     """Convert a single content file to HTML or PDF.
     """
@@ -211,6 +212,8 @@ def page(path_page, path_output, config, execute):
         config = ""
     if not execute:
         execute = "off"
+    else:
+        execute = "force"
 
     OUTPUT_PATH = path_output if path_output is not None else PATH_PAGE_FOLDER
     OUTPUT_PATH = Path(OUTPUT_PATH).joinpath("_build/html")

--- a/jupyter_book/commands/__init__.py
+++ b/jupyter_book/commands/__init__.py
@@ -233,8 +233,8 @@ def page(path_page, path_output, config, execute):
         "yaml_config_path": config,
         "globaltoc_path": "",
         "exclude_patterns": to_exclude,
-        "jupyter_execute_notebooks": execute,
         "html_theme_options": {"single_page": True},
+        "cli_overrides": {"jupyter_execute_notebooks": execute},
     }
 
     build_sphinx(

--- a/jupyter_book/commands/__init__.py
+++ b/jupyter_book/commands/__init__.py
@@ -199,8 +199,11 @@ def build(path_book, path_output, config, toc, warningiserror, builder):
 @click.argument("path-page")
 @click.option("--path-output", default=None, help="Path to the output artifacts")
 @click.option("--config", default=None, help="Path to the YAML configuration file")
-@click.option("--execute/--no-execute", default=True,
-              help="Whether to execute the notebook. Default is --execute")
+@click.option(
+    "--execute/--no-execute",
+    default=True,
+    help="Whether to execute the notebook. Default is --execute",
+)
 def page(path_page, path_output, config, execute):
     """Convert a single content file to HTML or PDF.
     """

--- a/jupyter_book/pdf.py
+++ b/jupyter_book/pdf.py
@@ -24,7 +24,7 @@ async def _html_to_pdf(html_file, pdf_file):
         from pyppeteer import launch
     except ImportError:
         _error(
-            "Generating PDF from book HTML requires the pyppetteer package. "
+            "Generating PDF from book HTML requires the pyppeteer package. "
             "Install it first.",
             ImportError,
         )

--- a/jupyter_book/sphinx.py
+++ b/jupyter_book/sphinx.py
@@ -36,7 +36,7 @@ DEFAULT_CONFIG = dict(
     },
     html_add_permalinks="¶",
     numfig=True,
-    cli_overrides={}, # Store CLI options that override _config parameters
+    cli_overrides={},  # Store CLI options that override _config parameters
 )
 
 

--- a/jupyter_book/sphinx.py
+++ b/jupyter_book/sphinx.py
@@ -36,6 +36,7 @@ DEFAULT_CONFIG = dict(
     },
     html_add_permalinks="¶",
     numfig=True,
+    cli_overrides={}, # Store CLI options that override _config parameters
 )
 
 

--- a/jupyter_book/yaml.py
+++ b/jupyter_book/yaml.py
@@ -90,6 +90,8 @@ def yaml_to_sphinx(yaml, config):
         sphinx_config["jupyter_execute_notebooks"] = execute.get("execute_notebooks")
         sphinx_config["jupyter_cache"] = execute.get("cache")
         sphinx_config["execution_excludepatterns"] = execute.get("exclude_patterns")
+    if config.jupyter_execute_notebooks:
+        sphinx_config["jupyter_execute_notebooks"] = config.jupyter_execute_notebooks
 
     # Update the theme options in the main config
     sphinx_config["html_theme_options"] = theme_options

--- a/jupyter_book/yaml.py
+++ b/jupyter_book/yaml.py
@@ -114,7 +114,7 @@ def yaml_to_sphinx(yaml, config):
         if key in yaml:
             sphinx_config[newkey] = yaml.pop(key)
 
-    # Ensures any configuration items specified via the CLI are not 
+    # Ensures any configuration items specified via the CLI are not
     # subsequently overwritten by the configuration in _config.yml
     for key, val in config.cli_overrides.items():
         sphinx_config[key] = val

--- a/jupyter_book/yaml.py
+++ b/jupyter_book/yaml.py
@@ -90,8 +90,6 @@ def yaml_to_sphinx(yaml, config):
         sphinx_config["jupyter_execute_notebooks"] = execute.get("execute_notebooks")
         sphinx_config["jupyter_cache"] = execute.get("cache")
         sphinx_config["execution_excludepatterns"] = execute.get("exclude_patterns")
-    if config.jupyter_execute_notebooks:
-        sphinx_config["jupyter_execute_notebooks"] = config.jupyter_execute_notebooks
 
     # Update the theme options in the main config
     sphinx_config["html_theme_options"] = theme_options
@@ -115,6 +113,11 @@ def yaml_to_sphinx(yaml, config):
     for key, newkey in YAML_TRANSLATIONS.items():
         if key in yaml:
             sphinx_config[newkey] = yaml.pop(key)
+
+    # Ensures any configuration items specified via the CLI are not 
+    # subsequently overwritten by the configuration in _config.yml
+    for key, val in config.cli_overrides.items():
+        sphinx_config[key] = val
 
     # Manual Sphinx over-rides will supercede other config
     sphinx_overrides = yaml.get("sphinx", {}).get("config")

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ test_reqs = [
     "matplotlib",
     "pytest-regressions",
     "jupytext",
+    "pyppeteer",
 ] + doc_reqs
 setup(
     name="jupyter-book",

--- a/tests/pages/nb_test_page_execute.ipynb
+++ b/tests/pages/nb_test_page_execute.ipynb
@@ -1,0 +1,34 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('foo')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -213,11 +213,11 @@ def test_build_page_execute(tmpdir):
     cell_out_div = r'<div class="cell_output docutils container">'
     assert cell_out_div in html
 
+
 def test_build_page_no_execute(tmpdir):
     """Test single page building with --no-execute flag."""
     path_output = Path(tmpdir).absolute()
     path_page = path_tests.joinpath("pages", "nb_test_page_execute.ipynb")
-
 
     run(
         f"jb page {path_page} --path-output {path_output} --no-execute".split(),

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -165,3 +165,38 @@ def test_build_page(tmpdir):
     assert path_html.joinpath("single_page.html").exists()
     # The extra page shouldn't have been built with Sphinx (or run)
     assert not path_html.joinpath("extra_page.html").exists()
+
+def test_build_page_execute(tmpdir):
+    """Test default execution of nb when building a single page."""
+    path_output = Path(tmpdir).absolute()
+    path_page = path_tests.joinpath("pages", "nb_test_page_execute.ipynb")
+
+    run(f"jb page {path_page} --path-output {path_output}".split(), check=True)
+    path_html = path_output.joinpath("_build", "html")
+    out_html = path_html.joinpath("nb_test_page_execute.html")
+    assert out_html.exists()
+    # The cell output div should be present in html generated from executed
+    # notebooks
+    with open(out_html, 'r') as fh:
+        html = fh.read()
+    cell_out_div = r'<div class="cell_output docutils container">'
+    assert cell_out_div in html
+
+def test_build_page_no_execute(tmpdir):
+    """Test single page building with --no-execute flag."""
+    path_output = Path(tmpdir).absolute()
+    path_page = path_tests.joinpath("pages", "nb_test_page_execute.ipynb")
+
+
+    run(
+        f"jb page {path_page} --path-output {path_output} --no-execute".split(),
+        check=True,
+    )
+    path_html = path_output.joinpath("_build", "html")
+    out_html = path_html.joinpath("nb_test_page_execute.html")
+    assert out_html.exists()
+    # No cell output div should be present in generated html
+    with open(out_html, 'r') as fh:
+        html = fh.read()
+    cell_out_div = r'<div class="cell_output docutils container">'
+    assert cell_out_div not in html

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -180,18 +180,17 @@ class TestPageExecute:
             f"jb page {self.path_page} --path-output {path_output} {flags}".split(),
             check=True,
         )
-        with open(out_html, 'r') as fh:
+        with open(out_html, "r") as fh:
             self.html = fh.read()
 
     @property
     def has_cell_output(self):
         return self.cell_out_div in self.html
 
-    @pytest.mark.parametrize(('flag', 'expected'), (
-        ("", True),
-        ("--execute", True),
-        ("--no-execute", False),
-    ))
+    @pytest.mark.parametrize(
+        ("flag", "expected"),
+        (("", True), ("--execute", True), ("--no-execute", False),),
+    )
     def test_build_page_execute_flags(self, tmpdir, flag, expected):
         self._run(tmpdir, flags=flag)
         assert self.has_cell_output == expected
@@ -208,7 +207,7 @@ def test_build_page_execute(tmpdir):
     assert out_html.exists()
     # The cell output div should be present in html generated from executed
     # notebooks
-    with open(out_html, 'r') as fh:
+    with open(out_html, "r") as fh:
         html = fh.read()
     cell_out_div = r'<div class="cell_output docutils container">'
     assert cell_out_div in html
@@ -227,7 +226,7 @@ def test_build_page_no_execute(tmpdir):
     out_html = path_html.joinpath("nb_test_page_execute.html")
     assert out_html.exists()
     # No cell output div should be present in generated html
-    with open(out_html, 'r') as fh:
+    with open(out_html, "r") as fh:
         html = fh.read()
     cell_out_div = r'<div class="cell_output docutils container">'
     assert cell_out_div not in html

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -166,6 +166,37 @@ def test_build_page(tmpdir):
     # The extra page shouldn't have been built with Sphinx (or run)
     assert not path_html.joinpath("extra_page.html").exists()
 
+
+class TestPageExecute:
+
+    basename = "nb_test_page_execute"
+    cell_out_div = r'<div class="cell_output docutils container">'
+    path_page = path_tests.joinpath("pages", f"{basename}.ipynb")
+
+    def _run(self, tmpdir, flags=""):
+        path_output = Path(tmpdir).absolute()
+        out_html = path_output.joinpath("_build", "html", f"{self.basename}.html")
+        run(
+            f"jb page {self.path_page} --path-output {path_output} {flags}".split(),
+            check=True,
+        )
+        with open(out_html, 'r') as fh:
+            self.html = fh.read()
+
+    @property
+    def has_cell_output(self):
+        return self.cell_out_div in self.html
+
+    @pytest.mark.parametrize(('flag', 'expected'), (
+        ("", True),
+        ("--execute", True),
+        ("--no-execute", False),
+    ))
+    def test_build_page_execute_flags(self, tmpdir, flag, expected):
+        self._run(tmpdir, flags=flag)
+        assert self.has_cell_output == expected
+
+
 def test_build_page_execute(tmpdir):
     """Test default execution of nb when building a single page."""
     path_output = Path(tmpdir).absolute()


### PR DESCRIPTION
Modifies the meaning of the --execute flag for the jb page command.

Using the click.options `--opt/--no-opt` pattern for boolean flags,
modify the behavior of jb page so that notebook targets are executed
by default, and can be toggled off by passing in the --no-execute
flag.

Marking as draft until added tests + update corresponding docs