### PR TITLE
FIX: fix bug when latex config not specified in project for "latex_documents"

### DIFF
--- a/jupyter_book/commands/__init__.py
+++ b/jupyter_book/commands/__init__.py
@@ -97,6 +97,7 @@ def build(path_book, path_output, config, toc, warningiserror, builder):
             # over a top level title
             if (
                 latex_config is not None
+                and "latex_documents" in latex_config.keys()
                 and "title" not in latex_config["latex_documents"].keys()
             ):
                 latex_config["latex_documents"]["title"] = config_yaml["title"]


### PR DESCRIPTION
This PR fixes a bug when `latex` config for `latex_documents` is not specified. 