### PR TITLE
TST: Fix test_pdf failure.

### DIFF
--- a/jupyter_book/pdf.py
+++ b/jupyter_book/pdf.py
@@ -24,7 +24,7 @@ async def _html_to_pdf(html_file, pdf_file):
         from pyppeteer import launch
     except ImportError:
         _error(
-            "Generating PDF from book HTML requires the pyppetteer package. "
+            "Generating PDF from book HTML requires the pyppeteer package. "
             "Install it first.",
             ImportError,
         )

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ test_reqs = [
     "matplotlib",
     "pytest-regressions",
     "jupytext",
+    "pyppeteer",
 ] + doc_reqs
 setup(
     name="jupyter-book",


### PR DESCRIPTION
In a clean environment, I see test errors in `test_pdf` due to `pyppeteer` not being installed. It's already in `setup.py` as a requirement for `pdfhtml`, but adding it to the test requirements as well prevents gets rid of the test failure.

Related to #626 but doesn't seem to be fixed there.

 * Include pyppeteer in test_reqs in setup.py as it is a requirement for
   test_pdf.py
 * Fix package name typo in error message.