### PR TITLE
TST: switch off building of docs for pdflatex (for now)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,13 +97,14 @@ jobs:
           command: pytest tests/test_pdf.py::test_pdflatex
 
       # Build Docs PDF as an artifact
-      - run:
-          name: PDF from LaTeX
-          command: jb build docs --builder pdflatex
+      # TODO: re-enable once gif, svg support is implemented for pdflatex
+      # - run:
+      #     name: PDF from LaTeX
+      #     command: jb build docs --builder pdflatex
 
-      - store_artifacts:
-          path: docs/_build/latex/python.pdf
-          destination: pdflatex
+      # - store_artifacts:
+      #     path: docs/_build/latex/python.pdf
+      #     destination: pdflatex
 
 workflows:
   version: 2


### PR DESCRIPTION
This PR switches **off** building of `docs` as an artifact via `circleci` for now until `pdflatex` handles the presence of complex mimetypes.

Currently the default sphinx builder issues a `warning` about these image types such as `gif`, `svg` but it passes the files as `URI` through to the latex and subsequently `xelatex` or `pdflatex` builds fail as these types of images are not supported in `\includegraphics` (See [Issue: #627](https://github.com/executablebooks/jupyter-book/issues/627))

**Note:** This does not switch off the `test_pdf:pdflatex` test case.  