### PR TITLE
TST: [pdflatex] Add build of quantecon-mini-example as a project style test case 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,13 +96,17 @@ jobs:
           name: Run pytest for pdflatex
           command: pytest tests/test_pdf.py::test_pdflatex
 
-      # Build Docs PDF as an artifact
+      # Build quantecon-mini-example project as a test case
       - run:
           name: PDF from LaTeX
-          command: jb build docs --builder pdflatex
+          command: |
+            git clone https://github.com/executablebooks/quantecon-mini-example.git
+            cd quantecon-mini-example/
+            pip install -r requirements.txt
+            jb build mini_book --builder pdflatex
 
       - store_artifacts:
-          path: docs/_build/latex/python.pdf
+          path: quantecon-mini-example/mini_book/_build/latex/python.pdf
           destination: pdflatex
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ jobs:
           command: pytest tests/test_pdf.py::test_pdflatex
 
       # Build quantecon-mini-example project as a test case
+      # TODO: revert this to building docs/ when we've added support for svg, gif, etc
       - run:
           name: PDF from LaTeX
           command: |


### PR DESCRIPTION
This PR adds the [quantecon-mini-example](https://github.com/executablebooks/quantecon-mini-example) as a large project style build test case as part of `pdflatex` testing in `circleci`. 

The artefact is stored as `pdflatex` after each run for viewing.

When this passes testing this will supersede #635 

**Note:** This PR switches off building of `docs` as an `pdf` via circleci for now and switches over to use `quantecon-mini-example`. The `docs` pages contain mimetypes that are currently incompatible with `pdflatex` builder