### PR TITLE
improving configuration under the hood

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
-*/_build/
+*_build
 tests/books/toc/_toc.yml
 
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 #######################################################################################
 # Book settings
-title:
+title: ""
 logo: images/logo.png
 author: The Jupyter Book Community
 email: choldgraf@berkeley.edu
@@ -19,7 +19,8 @@ html:
 
 repository:
   url                       : https://github.com/executablebooks/jupyter-book
-  path_to_book              : "docs"
+  branch                    : master
+  path_to_book              : docs
 
 launch_buttons:
   notebook_interface        : "jupyterlab"  # The interface interactive links will activate ["classic", "jupyterlab"]

--- a/jupyter_book/__init__.py
+++ b/jupyter_book/__init__.py
@@ -2,7 +2,6 @@
 from pathlib import Path
 
 from .toc import update_indexname, add_toctree
-from .yaml import add_yaml_config
 from .directive.toc import TableofContents
 
 
@@ -23,17 +22,19 @@ def add_static_files(app, config):
 # We connect this function to the step after the builder is initialized
 def setup(app):
 
+    # Updates `master_doc` using the first item of `_toc.yml`
     app.connect("config-inited", update_indexname)
+
+    # Add toctrees to each content page using `_toc.yml`
     app.connect("source-read", add_toctree)
 
+    # Path for `_toc.yml`
     app.add_config_value("globaltoc_path", "toc.yml", "env")
 
-    # configuration for YAML metadata
-    app.add_config_value("yaml_config_path", "", "html")
-
-    app.connect("config-inited", add_yaml_config)
+    # Add custom static files to the sphinx build
     app.connect("config-inited", add_static_files)
 
+    # Directives
     app.add_directive("tableofcontents", TableofContents)
 
     return {


### PR DESCRIPTION
This is an attempt at addressing some of the problems that @rossbar brought up earlier...

In this PR:

1. We no longer update the Sphinx configuration *within sphinx*, we instead define the Sphinx configuration in a python dictionary before calling sphinx build
2. The following precedence should take effect:

  1. Hard-coded jupyter book sphinx config
  2. Default Jupyter Book YAML
  3. User-provided `_config.yml`
  4. Over-rides from the command line

I *think* everything should behave the same, but we may run into issues with updating the configuration. I've tried to implement this in a "nested" fashion, AKA if a value is a dictionary, and it's updated with another value, then the dictionary is *updated* rather than replaced. This may or may not be appropriate in some circumstances and we should figure that out over time.

@rossbar WDYT?