### PR TITLE
TST: minor update to reference book.pdf rather than python.pdf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
             jb build mini_book --builder pdflatex
 
       - store_artifacts:
-          path: quantecon-mini-example/mini_book/_build/latex/python.pdf
+          path: quantecon-mini-example/mini_book/_build/latex/book.pdf
           destination: pdflatex
 
 workflows:


### PR DESCRIPTION
This just adjusts the test due to https://github.com/executablebooks/quantecon-mini-example/pull/26