### PR TITLE
How to reference docs and section labels

### DIFF
--- a/docs/content/citations.md
+++ b/docs/content/citations.md
@@ -133,12 +133,14 @@ There are a few ways to reference your book's content, depending on what kind of
 content you'd like to reference. Here is a quick overview of some common options:
 
 * `{ref}` is used to reference section labels that you define or figures with a `name` value
-  * You can reference a section label through ``{ref}`label` `` or ``{ref}`some text <label>` ``
-  * To reference a section label in another document try ``{ref}`path/to/document/label` ``
 * `{numref}` is used to provide *numbered* references to figures
 * `{doc}` is used to reference other files in your book
-  * Documents can be referenced through ``{doc}`path/to/document` `` or ``{doc}`some text <path/to/document>` ``
 * `{eq}` is used to reference equations that have been given a `label` value
+
+```{tip}
+You can reference a section label through ``{ref}`label` `` or ``{ref}`some text <label>` ``.
+Documents can be referenced through ``{doc}`path/to/document` `` or ``{doc}`some text <path/to/document>` ``
+```
 
 (citations/bibliography)=
 ## Bibliography

--- a/docs/content/citations.md
+++ b/docs/content/citations.md
@@ -133,8 +133,11 @@ There are a few ways to reference your book's content, depending on what kind of
 content you'd like to reference. Here is a quick overview of some common options:
 
 * `{ref}` is used to reference section labels that you define or figures with a `name` value
+  * You can reference a section label through ``{ref}`label` `` or ``{ref}`some text <label>` ``
+  * To reference a section label in another document try ``{ref}`path/to/document/label` ``
 * `{numref}` is used to provide *numbered* references to figures
 * `{doc}` is used to reference other files in your book
+  * Documents can be referenced through ``{doc}`path/to/document` `` or ``{doc}`some text <path/to/document>` ``
 * `{eq}` is used to reference equations that have been given a `label` value
 
 (citations/bibliography)=


### PR DESCRIPTION
This PR adds information about how to reference `doc` and `ref` roles. It addresses #648.

The cheatsheet provides detailed information with examples. It might be beneficial to point to each relevant cheatsheet section once PR #637 is merged successfully. What do you think @choldgraf?