### PR TITLE
ENH: Modify execute option for jb page command (#594 followup)

### DIFF
--- a/docs/start/build.md
+++ b/docs/start/build.md
@@ -54,8 +54,16 @@ jupyter-book page path/to/mypage.ipynb
 ```
 
 This will execute your content and output the proper HTML in a
-`_build/html` folder. Your page will be called `mypage.html`. This will work
-for any {doc}`content source file <../content-types/index>`) that is supported by Jupyter Book.
+`_build/html` folder.
+If you'd like to generate HTML for a page *without* executing any code cells,
+you can use the `--no-execute` flag:
+
+```
+jupyter-book page --no-execute path/to/mypage.ipynb
+```
+
+Your page will be called `mypage.html`. This will work
+for any {doc}`content source file <../content-types/index>` that is supported by Jupyter Book.
 
 ## Page caching
 

--- a/jupyter_book/commands/__init__.py
+++ b/jupyter_book/commands/__init__.py
@@ -194,7 +194,11 @@ def build(path_book, path_output, config, toc, warningiserror, builder):
 @click.argument("path-page")
 @click.option("--path-output", default=None, help="Path to the output artifacts")
 @click.option("--config", default=None, help="Path to the YAML configuration file")
-@click.option("--execute", default=None, help="Whether to execute the notebook first")
+@click.option(
+    "--execute/--no-execute",
+    default=True,
+    help="Whether to execute the notebook. Default is --execute",
+)
 def page(path_page, path_output, config, execute):
     """Convert a single content file to HTML or PDF.
     """
@@ -204,8 +208,12 @@ def page(path_page, path_output, config, execute):
     PAGE_NAME = PATH_PAGE.with_suffix("").name
     if config is None:
         config = ""
+
+    # Page command ignores book-level execution config options: page is either
+    # executed or not as dictated by command line option. Default is execute.
+    jupyter_execute_notebooks = "force"
     if not execute:
-        execute = "off"
+        jupyter_execute_notebooks = "off"
 
     OUTPUT_PATH = path_output if path_output is not None else PATH_PAGE_FOLDER
     OUTPUT_PATH = Path(OUTPUT_PATH).joinpath("_build/html")
@@ -225,7 +233,7 @@ def page(path_page, path_output, config, execute):
         "yaml_config_path": config,
         "globaltoc_path": "",
         "exclude_patterns": to_exclude,
-        "jupyter_execute_notebooks": execute,
+        "jupyter_execute_notebooks": jupyter_execute_notebooks,
         "html_theme_options": {"single_page": True},
     }
 

--- a/tests/pages/nb_test_page_execute.ipynb
+++ b/tests/pages/nb_test_page_execute.ipynb
@@ -1,0 +1,34 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('foo')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -165,3 +165,32 @@ def test_build_page(tmpdir):
     assert path_html.joinpath("single_page.html").exists()
     # The extra page shouldn't have been built with Sphinx (or run)
     assert not path_html.joinpath("extra_page.html").exists()
+
+
+class TestPageExecute:
+
+    basename = "nb_test_page_execute"
+    cell_out_div = r'<div class="cell_output docutils container">'
+    path_page = path_tests.joinpath("pages", f"{basename}.ipynb")
+
+    def _run(self, tmpdir, flags=""):
+        path_output = Path(tmpdir).absolute()
+        out_html = path_output.joinpath("_build", "html", f"{self.basename}.html")
+        run(
+            f"jb page {self.path_page} --path-output {path_output} {flags}".split(),
+            check=True,
+        )
+        with open(out_html, "r") as fh:
+            self.html = fh.read()
+
+    @property
+    def has_cell_output(self):
+        return self.cell_out_div in self.html
+
+    @pytest.mark.parametrize(
+        ("flag", "expected"),
+        (("", True), ("--execute", True), ("--no-execute", False),),
+    )
+    def test_build_page_execute_flags(self, tmpdir, flag, expected):
+        self._run(tmpdir, flags=flag)
+        assert self.has_cell_output == expected


### PR DESCRIPTION
This is essentially a re-submission of #594 after the changes to the configuration introduced in #647 . Adds a `--execute/--no-execute` binary flag to the `page` command to control whether or not cells are to be executed when building a single page.

This replaces the existing `--execute` flag, which expects a string to specify the desired building behavior (`'off'`, `'force'`, `'cache'`, or `'auto'`). This PR also changes the default behavior so that a page is *always* executed unless the `--no-execute` flag is specified, ignoring the book-level configuration option in `_config.yml`.

Also adds tests for single-page building to `test_build.py` (which should all pass once #677 is resolved) and updates the documentation to reflect the changed behavior.