### PR TITLE
adding configuration for source buttons

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,6 +15,8 @@ html:
   google_analytics_id: UA-52617120-7
   home_page_in_navbar: false
   use_edit_page_button: true
+  use_repository_button: true
+  use_issues_button: true
   baseurl: https://jupyterbook.org/
 
 repository:

--- a/docs/content/content-blocks.md
+++ b/docs/content/content-blocks.md
@@ -46,7 +46,7 @@ Here's a note block inside a margin block
 See {ref}`markdown/nexting` for instructions to do this.
 ````
 
-## Notes and warnings
+## Notes, warnings, and other admonitions
 
 Let's say you wish to highlight a particular block of
 text that exists slightly apart from the narrative of your page. You can
@@ -66,9 +66,22 @@ Results in the following output:
 Here is a note!
 ```
 
-Another common directive that result in similar output is **`{warning}`**.
+There are a number of similarly-styled blocks of text. For example, here is a `{warning}`
+block:
 
-Finally, you can choose the title of your message box by using the
+`````{warning}
+Here's a warning! It was created with:
+````
+```{warning}
+```
+````
+`````
+
+For a complete list of options, see [the `sphinx-book-theme` documentation](https://sphinx-book-theme.readthedocs.io/en/latest/reference/demo.html#admonitions).
+
+### Blocks of text with custom titles
+
+You can also choose the title of your message box by using the
 **`{admonition}`** directive. For example, the following text:
 
 ````
@@ -82,6 +95,20 @@ Results in the following output:
 ```{admonition} Here's your admonition
 Here's the admonition content
 ```
+
+If you'd like to **style these blocks**, then use the `:class:` option. For
+example:
+
+`````{admonition} This admonition was styled...
+:class: tip
+Using the following pattern:
+````
+```{admonition} My title
+:class: tip
+My content
+```
+````
+`````
 
 ## Quotations and epigraphs
 

--- a/docs/customize/config.md
+++ b/docs/customize/config.md
@@ -56,6 +56,56 @@ strings around them. For example, `false`, `true`, `off`, etc. In addition, pure
 numbers will be converted to `float` or `int` unless you put strings around them.
 ```
 
+## Add source repository buttons
+
+There are a collection of buttons that you can use to link back to your source
+repository. This lets users browse the repository, or take actions like suggest
+an edit or open an issue. In each case, they require the following configuration
+to exist:
+
+```yaml
+repository:
+  url: https://github.com/{your-book-url}
+```
+
+### Add a link to your repository
+
+To add a link to your repository, add the following configuration:
+
+```yaml
+repository:
+  url: https://github.com/{your-book-url}
+html:
+  use_repository_button: true
+```
+
+### Add a button to open issues
+
+To add a button to open an issue about the current page, use the following
+configuration:
+
+```yaml
+repository:
+  url: https://github.com/{your-book-url}
+html:
+  use_issues_button: true
+```
+
+### Add a button to suggest edits
+
+You can add a button to each page that will allow users to edit the page text
+directly and submit a pull request to update the documentation. To include this
+button, use the following configuration:
+
+```yaml
+repository:
+  url: https://github.com/{your-book-url}
+  path_to_book: path/to/your/book  # An optional path to your book, defaults to repo root
+  branch: yourbranch  # An optional branch, defaults to `master`
+html:
+  use_edit_page_button: true
+```
+
 ## Configuration reference
 
 For a reference example of *all* the possible Binder links and their default values, see the

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "sphinx_togglebutton",
         "sphinx-copybutton",
         "sphinxcontrib-bibtex",
-        "sphinx_book_theme",
+        "sphinx_book_theme>=0.0.21",
     ],
     extras_require={
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "pyyaml",
         "docutils>=0.15",
         "sphinx<3",
-        "myst-nb",
+        "myst-nb>=0.8.1",
         "click",
         "setuptools",
         "nbformat",


### PR DESCRIPTION
This adds configuration for a "source buttons" dropdown. It replaces the "edit_this_page" button which is now part of the dropdown.

closes #664 

also closes #680 since we now pin a version of sphinx-book-theme (and other packages)