### PR TITLE
[DOC] Fix rendering of subitems in ordered list

### DIFF
--- a/docs/reference/cheatsheet.md
+++ b/docs/reference/cheatsheet.md
@@ -236,19 +236,19 @@ Another alternative is to use markdown syntax:
 * - ```md
     1. First item
     2. Second item
-      1. First sub-item
+        1. First sub-item
     ```
   - 1. First item
     2. Second item
-      1. First sub-item
+        1. First sub-item
 * - ```md
     1. First item
     2. Second item
-      * First sub-item
+        * First sub-item
     ```
   - 1. First item
     2. Second item
-      * First subitem
+        * First subitem
 ``````
 
 ### Unordered List


### PR DESCRIPTION
This PR fixes the rendering of [myst-cheatsheet ordered-list](https://jupyterbook.org/reference/cheatsheet.html#ordered-list) by adding two additional spaces in front of each subitem.

It looks like subitems of ordered lists require more than 2 spaces to be recognized as subitems. This is not true for [unordered lists](https://jupyterbook.org/reference/cheatsheet.html#unordered-list).

This is what the current rendering with 2 space indentation looks like:
<img width="408" alt="Screen Shot 2020-06-03 at 12 20 03 PM" src="https://user-images.githubusercontent.com/33075058/83589150-5ea88000-a596-11ea-93d9-f2d2446a6cbf.png">

This seems a bit strange to me since markdown documentation doesn't mention this under [ordered lists](https://www.markdownguide.org/basic-syntax/#ordered-lists).