### PR TITLE
[DOC] Add info about 'remove_cell' tag

### DIFF
--- a/docs/content/content-blocks.md
+++ b/docs/content/content-blocks.md
@@ -176,6 +176,8 @@ Here's my figure:
 See {doc}`glue` for more information on how to use Glue to insert your outputs
 directly into your content.
 
+To hide code input and output where the variable is glued use the `remove_cell` tag. See {doc}`hiding` for more information and other tag options.
+
 ## Quotations and epigraphs
 
 Quotations and epigraphs provide ways to highlight information given by others.

--- a/docs/content/content-blocks.md
+++ b/docs/content/content-blocks.md
@@ -176,7 +176,10 @@ Here's my figure:
 See {doc}`glue` for more information on how to use Glue to insert your outputs
 directly into your content.
 
-To hide code input and output where the variable is glued use the `remove_cell` tag. See {doc}`hiding` for more information and other tag options.
+```{tip}
+To hide code input and output that generated the variable you are inserting, use the `remove_cell` tag.
+See {doc}`hiding` for more information and other tag options.
+```
 
 ## Quotations and epigraphs
 


### PR DESCRIPTION
Per @choldgraf's suggestion in #700 I have added some information about the `remove_cell` tag under https://jupyterbook.org/content/content-blocks.html#insert-code-cell-outputs-into-admonitions.

@choldgraf I would be happy to move the two sentences into a `note` directive if you think that's better.