### PR TITLE
[DOC] Add note about int eq labels in math directive

### DIFF
--- a/docs/content/math.md
+++ b/docs/content/math.md
@@ -96,7 +96,7 @@ w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
 
 
 ```{note}
-Integer equation labels and labels which start with an integer cannot be referenced and
+Labels cannot start with an integer, or they won't be able to be referenced and
 will throw a warning message if referenced. For example, `:label: 1` and `:label: 1eq` cannot
 be referenced.
 ```

--- a/docs/content/math.md
+++ b/docs/content/math.md
@@ -94,6 +94,12 @@ Will generate this:
 w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
 ```
 
+
+```{note}
+Integer equation labels cannot be referenced and
+will throw a warning message if referenced.
+```
+
 ### Linking to equations
 
 If you've created an equation with a label, you can link to it from within your text

--- a/docs/content/math.md
+++ b/docs/content/math.md
@@ -96,8 +96,9 @@ w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
 
 
 ```{note}
-Integer equation labels cannot be referenced and
-will throw a warning message if referenced.
+Integer equation labels and labels which start with an integer cannot be referenced and
+will throw a warning message if referenced. For example, `:label: 1` and `:label: 1eq` cannot
+be referenced.
 ```
 
 ### Linking to equations


### PR DESCRIPTION
This PR adds a `note` directive with information that integer math labels cannot be referenced. This could be helpful to LaTeX users who are used to integer equation labels and references.