### PR TITLE
[DOC] Add documentation for Google Colab launch buttons

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,14 +20,15 @@ html:
   baseurl: https://jupyterbook.org/
 
 repository:
-  url                       : https://github.com/executablebooks/jupyter-book
-  branch                    : master
-  path_to_book              : docs
+  url: https://github.com/executablebooks/jupyter-book
+  branch: master
+  path_to_book: docs
 
 launch_buttons:
-  notebook_interface        : "jupyterlab"  # The interface interactive links will activate ["classic", "jupyterlab"]
-  binderhub_url             : "https://mybinder.org"
-  thebelab                  : true
+  notebook_interface: "jupyterlab" # The interface interactive links will activate ["classic", "jupyterlab"]
+  binderhub_url: "https://mybinder.org"
+  colab_url: "https://colab.research.google.com"
+  thebelab: true
 
 sphinx:
   config:
@@ -36,8 +37,8 @@ sphinx:
         Macros:
           "N": "\\mathbb{N}"
           "floor": ["\\lfloor#1\\rfloor", 1]
-          "bmat" : ["\\left[\\begin{array}"]
-          "emat" : ["\\end{array}\\right]"]
+          "bmat": ["\\left[\\begin{array}"]
+          "emat": ["\\end{array}\\right]"]
   extra_extensions:
     - sphinx_click.ext
     - sphinx_tabs.tabs

--- a/docs/interactive/launchbuttons.ipynb
+++ b/docs/interactive/launchbuttons.ipynb
@@ -42,6 +42,21 @@
     "By adding this configuration, along with the repository url configuration above, Jupyter Book\n",
     "will insert Binder links to any pages that were built from notebook content.\n",
     "\n",
+    "## Google Colab buttons for your pages\n",
+    "\n",
+    "If your Jupyter Book is hosted online on GitHub, you can automatically insert buttons that link to the Jupyter Notebook running on [Google Colab](https://colab.research.google.com/). When a user clicks the button, they'll be taken to a live version of the page.\n",
+    "\n",
+    "Similar to Binder link buttons, you can automatically include Google Colab link buttons with the following configuration in `_config.yml`:\n",
+    "\n",
+    "```yaml\n",
+    "launch_buttons:\n",
+    "  colab_url: \"https://colab.research.google.com\"\n",
+    "```\n",
+    "\n",
+    "```{note}\n",
+    "Google Colab links will only work for pages that have the `.ipynb` extension.\n",
+    "```\n",
+    "\n",
     "## Creating interact buttons for JupyterHub\n",
     "\n",
     "JupyterHub lets you host an online service that gives users their own Jupyter servers\n",
@@ -181,7 +196,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.3"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/interactive/launchbuttons.ipynb
+++ b/docs/interactive/launchbuttons.ipynb
@@ -42,7 +42,7 @@
     "By adding this configuration, along with the repository url configuration above, Jupyter Book\n",
     "will insert Binder links to any pages that were built from notebook content.\n",
     "\n",
-    "## Google Colab buttons for your pages\n",
+    "## {term}`Google Colab` buttons for your pages\n",
     "\n",
     "If your Jupyter Book is hosted online on GitHub, you can automatically insert buttons that link to the Jupyter Notebook running on [Google Colab](https://colab.research.google.com/). When a user clicks the button, they'll be taken to a live version of the page.\n",
     "\n",

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -44,6 +44,10 @@ A glossary of common terms used throughout Jupyter Book.
     runs on Kubernetes and utilizes a {term}`JupyterHub` in order to provide live, reproducible
     interactive computing environments that users host on GitHub.
 
+[Google Colab](https://colab.research.google.com/)
+    A Jupyter Notebook service from Google that provides access to free computing resources,
+    including GPUs and TPUs.
+
 [JupyterHub](https://jupyterhub.readthedocs.io/en/stable/)
     A core open source tool from the Jupyter community, JupyterHub allows you to
     deploy an application that provides remote data science environments to multiple


### PR DESCRIPTION
* Add instructions on how to include Google Colab launch buttons 
* Include `colab_url` in the configuraiton of the docs
* Add description of Colab to Glossary and include link in docs

Note: I was not sure whether _Google Colab_ should be included in the Glossary - happy to add it if needed.

Sample output in the docs provided below.

_**Top bar:**_
![Screen Shot 2020-06-21 at 11 54 30 am](https://user-images.githubusercontent.com/26859204/85221679-1373d700-b3b6-11ea-8bfc-dd1ba28cab02.png)

_**Section:**_
![Screen Shot 2020-06-21 at 11 54 37 am](https://user-images.githubusercontent.com/26859204/85221684-1a9ae500-b3b6-11ea-8c8b-a4afab930220.png)

Closes #716 
