### PR TITLE
render toc paths as posix strings for windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,11 +101,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[testing]
 
-    - name: Install Headless Chrome dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -yq $(cat .github/workflows/pyppeteer_reqs.txt)
-
     # Tests
     - name: Run pytest
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -86,6 +86,16 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+  test-windows:
+    name: Tests on Windows
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -100,6 +110,7 @@ jobs:
     - name: Run pytest
       run: |
         pytest --durations=10 --ignore=tests/test_pdf.py
+
 
   # Build the book on OSX to make sure that building the docs works there too
   build-book-osx:

--- a/jupyter_book/__init__.py
+++ b/jupyter_book/__init__.py
@@ -14,9 +14,9 @@ def add_static_files(app, config):
     for path in static_paths:
         path = Path(app.confdir).joinpath(path)
         for path_css in path.rglob("*.css"):
-            app.add_css_file(str(path_css.relative_to(path)))
+            app.add_css_file((path_css.relative_to(path)).as_posix())
         for path_js in path.rglob("*.js"):
-            app.add_js_file(str(path_js.relative_to(path)))
+            app.add_js_file((path_js.relative_to(path)).as_posix())
 
 
 # We connect this function to the step after the builder is initialized

--- a/jupyter_book/sphinx.py
+++ b/jupyter_book/sphinx.py
@@ -193,16 +193,11 @@ def build_sphinx(
     app = None  # In case we fail, this allows us to handle the exception
     try:
         # This patch is what Sphinx does, so we copy it blindly...
-        sourcedir_posix = sourcedir.as_posix()
-        outputdir_posix = outputdir.as_posix()
-        confdir_posix = confdir
-        if confdir:
-            confdir_posix = confdir.as_posix()
         with patch_docutils(confdir), docutils_namespace():
             app = Sphinx(
-                srcdir=sourcedir_posix,
-                confdir=confdir_posix,
-                outdir=outputdir_posix,
+                srcdir=sourcedir,
+                confdir=confdir,
+                outdir=outputdir,
                 doctreedir=doctreedir,
                 buildername=builder,
                 confoverrides=sphinx_config,
@@ -215,6 +210,10 @@ def build_sphinx(
                 parallel=jobs,
                 keep_going=keep_going,
             )
+            app.srcdir = Path(app.srcdir).as_posix()
+            app.outdir = Path(app.outdir).as_posix()
+            app.confdir = Path(app.confdir).as_posix()
+            app.doctreedir = Path(app.doctreedir).as_posix()
             # Apply Latex Overrides for latex_documents
             if (
                 latexoverrides is not None
@@ -246,7 +245,6 @@ def build_sphinx(
                     )
             else:
                 path_toc = None
-
             if not path_index.exists() and path_toc:
                 toc = yaml.safe_load(path_toc.read_text(encoding="utf8"))
                 if isinstance(toc, dict):

--- a/jupyter_book/sphinx.py
+++ b/jupyter_book/sphinx.py
@@ -90,7 +90,6 @@ def build_sphinx(
     default_yaml_config = yaml.safe_load(PATH_YAML_DEFAULT.read_text(encoding="utf8"))
     new_config = yaml_to_sphinx(default_yaml_config)
     _recursive_update(sphinx_config, new_config)
-
     # Update with the given config file, if it exists
     if path_config:
         path_config = Path(path_config)
@@ -194,11 +193,16 @@ def build_sphinx(
     app = None  # In case we fail, this allows us to handle the exception
     try:
         # This patch is what Sphinx does, so we copy it blindly...
+        sourcedir_posix = sourcedir.as_posix()
+        outputdir_posix = outputdir.as_posix()
+        confdir_posix = confdir
+        if confdir:
+            confdir_posix = confdir.as_posix()
         with patch_docutils(confdir), docutils_namespace():
             app = Sphinx(
-                srcdir=sourcedir,
-                confdir=confdir,
-                outdir=outputdir,
+                srcdir=sourcedir_posix,
+                confdir=confdir_posix,
+                outdir=outputdir_posix,
                 doctreedir=doctreedir,
                 buildername=builder,
                 confoverrides=sphinx_config,
@@ -250,7 +254,7 @@ def build_sphinx(
                 else:
                     first_page = toc[0]["file"]
                 first_page = first_page.split(".")[0] + ".html"
-                with open(path_index, "w") as ff:
+                with open(path_index, "w", encoding="utf8") as ff:
                     ff.write(REDIRECT_TEXT.format(first_page=first_page))
             return app.statuscode
     except (Exception, KeyboardInterrupt) as exc:

--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -118,7 +118,9 @@ def add_toctree(app, docname, source):
         for ipage in isection.get("sections"):
             if ipage.get("file"):
                 # Update path so it is relative to the root of the parent
-                path_sec = os.path.relpath(ipage.get("file"), path_parent_folder)
+                path_sec = Path(
+                    os.path.relpath(ipage.get("file"), path_parent_folder)
+                ).as_posix()
             elif ipage.get("url"):
                 path_sec = ipage.get("url")
             else:
@@ -137,7 +139,6 @@ def add_toctree(app, docname, source):
         # Generate the TOCtree for this page
         toctrees.append(_gen_toctree(toc_options, toc_sections, parent_suff))
     toctrees = "\n".join(toctrees)
-
     # Now modify the source file with the new toctree text
     if parent_suff in [".md", ".rst"]:
         source[0] += "\n\n" + toctrees + "\n"  # Add two \n to ensure no clash w/ text
@@ -176,7 +177,6 @@ def add_toc_to_sphinx(app, config):
 
     # Check for proper structure, naming, etc
     _check_toc_entries([toc])
-
     # Rename top-level `chapters` to `sections`
     for isection in toc.get("sections", []):
         if isection.get("chapters"):

--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,6 @@ setup(
         "pyyaml",
         "docutils>=0.15",
         "sphinx<3",
-        "myst-nb~=0.8.0",
-        # this is required by the current markdow-it-py
-        # but can be remove when moving to myst-nb 0.9
-        "attrs~=19.3",
         "click",
         "setuptools",
         "nbformat",
@@ -68,6 +64,7 @@ setup(
         "sphinx_book_theme>=0.0.34",
         "sphinx-thebe>=0.0.6",
         "jupyter-sphinx @ git+https://github.com/jupyter/jupyter-sphinx@master",
+        "myst-nb @ git+git://github.com/foster999/MyST-NB@master",
     ],
     extras_require={
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         "sphinxcontrib-bibtex",
         "sphinx_book_theme>=0.0.34",
         "sphinx-thebe>=0.0.6",
+        "jupyter-sphinx @ git+https://github.com/jupyter/jupyter-sphinx@master",
     ],
     extras_require={
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],


### PR DESCRIPTION
this fixes #573 on windows -- specfically, the problem that
toc.py could not parse paths to folders, because
`str(Path("docs/about_py"))` on windows is rendered as `docs\\about_py`.
The solution is use the Path().as_posix() member function
to render paths uniformly on windows and unix.

There are two open issues remaining:

1.  1 of the 5 toc tests (test_toc_urllink) is failing on windows.
2. @choldgraf -- could use some guidance on the following:
    the `toctree` directive is producing links with absolute instead of
    relative paths, so the top of page index links are broken, although the sidebar works:
    i.e.  https://github.com/phaustin/jb_windows_test/blob/master/multi_level/toc/_toc.yml
    generates:
    https://phaustin.github.io/jb_windows_test/multi_level/html/index.html
    