### PR TITLE
🐛 FIX: fixing chapters numbering

### DIFF
--- a/docs/customize/toc.md
+++ b/docs/customize/toc.md
@@ -110,37 +110,39 @@ We recommend nesting your sections no more than 3 layers deep (as shown above).
 ## Number your book's sections
 
 You can automatically add numbers to each section of your book. To add numbers
-to any section or subsection of the book, add the `numbered: true` flag to its
-entry in your `_toc.yml` file. For example:
+to **all sections of your book**, add the `numbered: true` flag to
+your introduction page entry (the first entry in `_toc.yml`). For example:
 
-````{list-table}
-:header-rows: 1
+```yaml
+- file: home
+  numbered: true
+- file: page2
+- file: page3
+- file: page4
+```
 
-* - Files
-  - Chapters
-* - ```yaml
-    - file: myfolder/mypage
-      numbered: true
-      sections:
-      - file: myfolder/mysubpage
-    ```
-  - ```yaml
-    - chapter: My chapter
-      numbered: true
-      sections:
-      - file: myfolder/mypage
-        numbered: true
-        sections:
-        - file: myfolder/mysubpage
-    ```
-````
-
-This will cause both `myfolder/mypage` as well as `myfolder/asubpage` to be
+This will cause all sections of the book to be
 numbered. They will follow a hierarchy according to the sub-sections structure
 defined in your `_toc.yml` file.
 
-To number *all* of the sections of your book, add the `numbered: true` flag to
-the first entry of your `_toc.yml` file.
+If you'd like to number **subsets of sections**, group them into chapters and
+apply the `numbered: true` flag to the chapters that you wish to be numbered.
+For example:
+
+```yaml
+- file: home
+  numbered: true
+# This chapter will not be numbered
+- chapter: Introduction
+  sections:
+  - file: page2
+# This chapter will be numbered
+- chapter: Chapter 1
+  numbered: true
+  sections:
+  - file: page3
+  - file: page4
+```
 
 ### Numbering caveats and notes
 

--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -71,10 +71,7 @@ def add_toctree(app, docname, source):
     # Check if subsections are all individual files. If so, embed them in a section
     are_files = [("file" in ii) or ("url" in ii) for ii in sections]
     if all(are_files):
-        sections = {"chapter": "", "sections": sections}
-        if "numbered" in parent_page:
-            sections["numbered"] = True
-        sections = [sections]
+        sections = [{"chapter": "", "sections": sections}]
     elif any(are_files) and not all(are_files):
         raise ValueError(
             f"Mixed chapters and individual files in `_toc.yml` entry {parent_name}"
@@ -85,7 +82,7 @@ def add_toctree(app, docname, source):
     for isection in sections:
         # Check for TOC options (that generally only change behavior on top-level page)
         toc_options = {}
-        if "numbered" in isection and isection.get("numbered") is not False:
+        if isection.get("numbered") or parent_page.get("numbered"):
             toc_options["numbered"] = ""  # Empty string will == a flag in the toctree
         if isection.get("chapter"):
             toc_options["caption"] = isection.get("chapter")

--- a/tests/books/toc/_toc_numbered_chapters.yml
+++ b/tests/books/toc/_toc_numbered_chapters.yml
@@ -1,0 +1,18 @@
+- file: index
+  title: Toc
+  numbered: true
+- chapter: Chapter 1
+  sections:
+  - file: content1
+    title: Content1
+  - file: subfolder/index
+    title: Subfolder
+    sections:
+    - file: subfolder/asubpage
+      title: Asubpage
+- chapter: Chapter 2
+  sections:
+  - file: content2
+    title: Content2
+  - file: content3
+    title: Content3

--- a/tests/books/toc/_toc_numbered_chapters_subset.yml
+++ b/tests/books/toc/_toc_numbered_chapters_subset.yml
@@ -1,0 +1,21 @@
+- file: index
+  title: Toc
+- chapter: Chapter 1
+  numbered: true
+  sections:
+  - file: content1
+    title: Content1
+- chapter: Chapter 2
+  sections:
+  - file: content2
+    title: Content2
+  - file: content3
+    title: Content3
+- chapter: Chapter 3
+  numbered: true
+  sections:
+  - file: subfolder/index
+    title: Subfolder
+    sections:
+    - file: subfolder/asubpage
+      title: Asubpage

--- a/tests/test_toc/_toc_numbered.html
+++ b/tests/test_toc/_toc_numbered.html
@@ -1,0 +1,31 @@
+<nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
+<ul class="nav sidenav_l1">
+<li class="toctree-l1">
+<a class="reference internal" href="#">
+   Main index
+  </a>
+</li>
+</ul>
+<ul class="nav sidenav_l1">
+<li class="toctree-l1">
+<a class="reference internal" href="content1.html">
+   1. Content1
+  </a>
+</li>
+<li class="toctree-l1">
+<a class="reference internal" href="subfolder/index.html">
+   2. Subfolder
+  </a>
+</li>
+<li class="toctree-l1">
+<a class="reference internal" href="content2.html">
+   3. Content2
+  </a>
+</li>
+<li class="toctree-l1">
+<a class="reference internal" href="content3.html">
+   4. Content3
+  </a>
+</li>
+</ul>
+</nav>

--- a/tests/test_toc/_toc_numbered_chapters.html
+++ b/tests/test_toc/_toc_numbered_chapters.html
@@ -6,6 +6,11 @@
   </a>
 </li>
 </ul>
+<p class="caption">
+<span class="caption-text">
+  Chapter 1
+ </span>
+</p>
 <ul class="nav sidenav_l1">
 <li class="toctree-l1">
 <a class="reference internal" href="content1.html">
@@ -17,14 +22,21 @@
    2. Subfolder
   </a>
 </li>
+</ul>
+<p class="caption">
+<span class="caption-text">
+  Chapter 2
+ </span>
+</p>
+<ul class="nav sidenav_l1">
 <li class="toctree-l1">
 <a class="reference internal" href="content2.html">
-   3. Content2
+   1. Content2
   </a>
 </li>
 <li class="toctree-l1">
 <a class="reference internal" href="content3.html">
-   4. Content3
+   2. Content3
   </a>
 </li>
 </ul>

--- a/tests/test_toc/_toc_numbered_chapters_subset.html
+++ b/tests/test_toc/_toc_numbered_chapters_subset.html
@@ -1,0 +1,50 @@
+<nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
+<ul class="nav sidenav_l1">
+<li class="toctree-l1">
+<a class="reference internal" href="#">
+   Main index
+  </a>
+</li>
+</ul>
+<p class="caption">
+<span class="caption-text">
+  Chapter 1
+ </span>
+</p>
+<ul class="nav sidenav_l1">
+<li class="toctree-l1">
+<a class="reference internal" href="content1.html">
+   1. Content1
+  </a>
+</li>
+</ul>
+<p class="caption">
+<span class="caption-text">
+  Chapter 2
+ </span>
+</p>
+<ul class="nav sidenav_l1">
+<li class="toctree-l1">
+<a class="reference internal" href="content2.html">
+   Content2
+  </a>
+</li>
+<li class="toctree-l1">
+<a class="reference internal" href="content3.html">
+   Content3
+  </a>
+</li>
+</ul>
+<p class="caption">
+<span class="caption-text">
+  Chapter 3
+ </span>
+</p>
+<ul class="nav sidenav_l1">
+<li class="toctree-l1">
+<a class="reference internal" href="subfolder/index.html">
+   1. Subfolder
+  </a>
+</li>
+</ul>
+</nav>

--- a/tests/test_tocdirective.py
+++ b/tests/test_tocdirective.py
@@ -64,22 +64,3 @@ def test_toc_urllink(tmpdir, file_regression):
     soup = BeautifulSoup(path_toc_directive.read_text(encoding="utf8"), "html.parser")
     toc = soup.find_all("div", class_="tableofcontents-wrapper")[0]
     file_regression.check(str(toc), extension=".html")
-
-
-def test_toc_numbered(tmpdir, file_regression):
-    """Testing that numbers make it into the sidebar"""
-    path_output = Path(tmpdir).joinpath("mybook").absolute()
-    # Regular TOC should work
-    p_toc = path_books.joinpath("toc")
-    path_toc = p_toc.joinpath("_toc_numbered.yml")
-    run(
-        f"jb build {p_toc} --path-output {path_output} --toc {path_toc} -W".split(),
-        check=True,
-    )
-
-    path_toc_directive = path_output.joinpath("_build", "html", "index.html")
-
-    # get the tableofcontents markup
-    soup = BeautifulSoup(path_toc_directive.read_text(encoding="utf8"), "html.parser")
-    toc = soup.select("nav.bd-links")[0]
-    file_regression.check(str(toc), extension=".html")


### PR DESCRIPTION
This fixes the numbering for some chapters when we have a top-level file w/ `numbered: true`