### PR TITLE
[FIX] `jb build` on Windows with book contents in sub-directories

### DIFF
--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -125,6 +125,9 @@ def add_toctree(app, docname, source):
                     f"in page {parent_name}"
                 )
 
+            # Replace Windows path seperator
+            path_sec = path_sec.replace(os.sep, "/")
+
             # Decide whether we'll over-ride with a title in the toctree
             if ipage.get("title"):
                 this_section = f"{ipage.get('title')} <{path_sec}>"

--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -235,7 +235,7 @@ def _content_path_to_yaml(path, root_path, split_char="_", add_titles=True):
         title = _filename_to_title(path.name, split_char=split_char)
 
     path_rel_root = path.relative_to(root_path)
-    out = {"file": str(path_rel_root.with_suffix(""))}
+    out = {"file": str(path_rel_root.with_suffix("")).replace(os.sep, "/")}
     if add_titles:
         out["title"] = title
     return out


### PR DESCRIPTION
# Issue

Building a book from files in sub-directories currently raises warnings and book does not include files from sub-dirs.

For the example `_toc.yml`:
```
file: intro
sections:
- file: section_1/section_1_content
```

The following warnings are raised when building with `jupyter-book build .`:
* `\book\intro.md:4: WARNING: toctree contains reference to nonexisting document 'section_1/section_1_content'`
* `book\section_1\section_1_content: WARNING: document isn't included in any toctree`

# Fix

This PR replaces the OS path separator with `/` when:
* building html with `_toc.yml` using `jupyter-book build .` - fixes the warnings above. Either `/` or `\` can be used in `_toc.yml`.
* building `_toc.yml` using `jupyter-book toc .` - this is not required given the first fix, but as `\` does not build on Ubuntu this change should make the resulting files portable between Windows and non-windows OS's.

Fixes #804 