### PR TITLE
🔧 MAINT: bump sphinx version to allow for 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     install_requires=[
         "pyyaml",
         "docutils>=0.15",
-        "sphinx<3",
+        "sphinx<4",
         "myst-nb~=0.8",
         "click",
         "setuptools",


### PR DESCRIPTION
Bumping the Sphinx version to 3 to see what breaks.

closes https://github.com/executablebooks/jupyter-book/issues/870