### PR TITLE
📚 DOCS: Add Google Colab in the Launch Buttons

### DIFF
--- a/jupyter_book/default_config.yml
+++ b/jupyter_book/default_config.yml
@@ -41,6 +41,7 @@ launch_buttons:
   binderhub_url             : https://mybinder.org  # The URL of the BinderHub (e.g., https://mybinder.org)
   jupyterhub_url            : ""  # The URL of the JupyterHub (e.g., https://datahub.berkeley.edu)
   thebe                     : false  # Add a thebe button to pages (requires the repository to run on Binder)
+  colab_url                 : https://colab.research.google.com # The URL of Google Colab (e.g., https://colab.research.google.com)
 
 repository:
   url                       : https://github.com/executablebooks/jupyter-book  # The URL to your book's repository


### PR DESCRIPTION
Add configuration value to launch Google Colab in the [Configuration Reference](https://jupyterbook.org/customize/config.html#configuration-reference)

closes https://github.com/executablebooks/jupyter-book/issues/788