### PR TITLE
📚 DOC: Provide more documentation on hosting services

### DIFF
--- a/docs/publish/gh-pages.md
+++ b/docs/publish/gh-pages.md
@@ -49,7 +49,12 @@ Note this warning from the [`ghp-import` GitHub repository](https://github.com/d
 
 ## Automatically host your book with GitHub Actions
 
-[GitHub Actions](https://docs.github.com/en/actions) is a tool that allows you to automate things on GitHub. It is used for a variety of things, such as testing, publishing packages, and continuous integration.
+[GitHub Actions](https://docs.github.com/en/actions) is a tool that allows you to automate things on GitHub.
+It is used for a variety of things, such as testing, publishing packages, and continuous integration.
+
+Note that if you're not hosting your book on GitHub,
+or if you'd like another, user-friendly service to build it automatically,
+see the {doc}`guide to publishing your book on Netlify <../netlify>`.
 
 ```{note}
 You should be familiar with GitHub Actions before using them

--- a/docs/publish/netlify.md
+++ b/docs/publish/netlify.md
@@ -4,6 +4,11 @@
 **automatically build an updated copy of your Jupyter Book** as you push new content.
 It can be used across git clients including GitHub, GitLab, and Bitbucket.
 
+Note that these instructions assume you're keeping your source files under version-control,
+rather than the built Jupyter Book HTML.
+If you're pushing your HTML to GitHub,
+you'll want to {doc}`host your book on GitHub Pages <../gh-pages>` instead.
+
 Although Netlify has both free and paid tiers, the build process is the same across both.
 Importantly, the free tier only allows for 100GB of bandwidth usage per month across all of your Netlify built projects.
 
@@ -49,6 +54,7 @@ Authorizing access will take you to the next step of the build process, where yo
 If your book content is not in the root of your repository, make sure you point to it
 in the `jupyter-book build` command.
 ```
+
 Once you've selected the correct repository, you'll need to supply build instructions.
 This is a command that Netlify runs before hosting your site. We'll use it to do the
 following:


### PR DESCRIPTION
Closes #709.

Provides more detail on existing hosting solutions. Specifically:

- Specifies that if you have already built your book's HTML, we recommend GitHub pages
- Recommends Netlify over GitHub Actions, if you can't host your book on GitHub

Right now these are in-text, but I'm happy to convert them to admonitions if you think it's useful !