### PR TITLE
📚 DOCS: Fix contributing guide syntax

### DIFF
--- a/docs/contribute/intro.md
+++ b/docs/contribute/intro.md
@@ -60,7 +60,10 @@ This will run the Jupyter Book test suite, *except for the PDF tests*. This is b
 running the PDF generation tests require a full Latex environment, which you may not have
 set up.
 
-```{note} Jupyter Book makes use of [pytest-xdist](https://github.com/pytest-dev/pytest-xdist) for running tests in parallel. You can take advantage of this by running tests with the `-n` argument followed by the number of CPUs you would like to use. For example: `pytest -n 4`. This makes the tests run much faster.
+```{note}
+Jupyter Book makes use of [pytest-xdist](https://github.com/pytest-dev/pytest-xdist) for running tests in parallel.
+You can take advantage of this by running tests with the `-n` argument followed by the number of CPUs you would like to use.
+For example: `pytest -n 4`. This makes the tests run much faster.
 ```
 
 ### To test PDF generation


### PR DESCRIPTION
Closes None :disappointed: 

Currently, the contributing guide has a typo that prevents it from rendering properly. This can be seen in the included screenshot, or by navigating to https://jupyterbook.org/contribute/intro.html. This PR fixes the rendering to ease interacting with the content.

![Screenshot from 2020-08-18 10-36-55](https://user-images.githubusercontent.com/15017191/90527231-4e3c8600-e13f-11ea-9fd1-bd6c0e0a69e2.png)
