### PR TITLE
[DOC] switch off myst_override_mathjax to enable Tex Config

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -32,6 +32,7 @@ launch_buttons:
 
 sphinx:
   config:
+    myst_override_mathjax: false
     mathjax_config:
       TeX:
         Macros:


### PR DESCRIPTION
This PR fixes the passthrough of [sphinx_config](https://github.com/executablebooks/jupyter-book/blob/fa16b2336edc4fabe039467cb0a509a4ea5823de/docs/_config.yml#L35) for `mathjax` configuration via `_config.yml` on [this page of the docs](https://jupyterbook.org/advanced/sphinx.html#defining-tex-macros)

This is related to #909 

@chrisjsewell do you know if switching this off affects some other part of the `docs`?