### PR TITLE
📚 DOCS: add sphinx-panels tabbed example

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,6 @@ repos:
     - id: flake8
 
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -76,6 +76,9 @@ sphinx:
       nbformat:
         - "https://nbformat.readthedocs.io/en/latest"
         - null
+      sphinx-panels:
+        - https://sphinx-panels.readthedocs.io/en/latest/
+        - null
     rediraffe_branch: 'master'
     rediraffe_redirects:
       content-types/index.md: file-types/index.md

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -77,7 +77,7 @@ sphinx:
         - "https://nbformat.readthedocs.io/en/latest"
         - null
       sphinx-panels:
-        - https://sphinx-panels.readthedocs.io/en/latest/
+        - https://sphinx-panels.readthedocs.io/en/sphinx-book-theme/
         - null
     rediraffe_branch: 'master'
     rediraffe_redirects:

--- a/docs/content/content-blocks.md
+++ b/docs/content/content-blocks.md
@@ -447,7 +447,7 @@ becomes {term}`A second term`.
 
 ## Tabbed content
 
-You can also use [`sphinx-panels`](https://sphinx-panels.readthedocs.io/en/latest) to produced [**tabbed content**](https://sphinx-panels.readthedocs.io/en/latest/#tabbed-content). This allows you to display a variety of tabbed content blocks that users can click between.
+You can also use [`sphinx-panels`](sphinx-panels:panels/usage) to produced [**tabbed content**](sphinx-panels:components-tabbed). This allows you to display a variety of tabbed content blocks that users can click between.
 
 For example, here's a group of tabs showing off code in a few different languages:
 
@@ -523,7 +523,7 @@ My first tab
 My second tab with `some code`!
 ```
 
-See the [`sphinx-tabs`](https://sphinx-panels.readthedocs.io/en/latest/#tabbed-content) documentation for more information about how to use this.
+See the [`sphinx-panels` tabbed](sphinx-panels:components-tabbed) documentation for more information about how to use this.
 
 
 ## Citations and cross-references

--- a/docs/content/content-blocks.md
+++ b/docs/content/content-blocks.md
@@ -445,6 +445,87 @@ To reference terms in your glossary, use the `{term}` role. For example,
 `` {term}`term one` `` becomes {term}`term one`. And `` {term}`A second term` ``
 becomes {term}`A second term`.
 
+## Tabbed content
+
+You can also use [`sphinx-panels`](https://sphinx-panels.readthedocs.io/en/latest) to produced [**tabbed content**](https://sphinx-panels.readthedocs.io/en/latest/#tabbed-content). This allows you to display a variety of tabbed content blocks that users can click between.
+
+For example, here's a group of tabs showing off code in a few different languages:
+
+````{tabbed} c++
+
+```{code-block} c++
+
+int main(const int argc, const char **argv) {
+  return 0;
+}
+```
+````
+
+````{tabbed} python
+
+```{code-block} python
+
+def main():
+    return
+```
+````
+
+````{tabbed} java
+
+```{code-block} java
+
+class Main {
+    public static void main(String[] args) {
+    }
+}
+```
+````
+
+````{tabbed} julia
+
+```{code-block} julia
+
+function main()
+end
+```
+````
+
+````{tabbed} fortran
+
+```{code-block} fortran
+
+PROGRAM main
+END PROGRAM main
+```
+````
+
+You can use this functionality with the `{tabbed}` directive. You can provide a sequence of `{tabbed}` directives, and each one will be used to generate a new tab (unless the `:new-group:` option is added to a `{tabbed}` directive.)
+
+For example, the following code:
+
+````
+```{tabbed} Tab 1 title
+My first tab
+```
+
+```{tabbed} Tab 2 title
+My second tab with `some code`!
+```
+````
+
+Produces:
+
+```{tabbed} Tab 1 title
+My first tab
+```
+
+```{tabbed} Tab 2 title
+My second tab with `some code`!
+```
+
+See the [`sphinx-tabs`](https://sphinx-panels.readthedocs.io/en/latest/#tabbed-content) documentation for more information about how to use this.
+
+
 ## Citations and cross-references
 
 You can add citations and cross-references to your book's content. See

--- a/jupyter_book/commands/__init__.py
+++ b/jupyter_book/commands/__init__.py
@@ -280,7 +280,8 @@ def create(path_book, cookiecutter):
             from cookiecutter.main import cookiecutter
         except ModuleNotFoundError as e:
             _error(
-                f"{e}. To install, run\n\n\tpip install cookiecutter", kind=e.__class__,
+                f"{e}. To install, run\n\n\tpip install cookiecutter",
+                kind=e.__class__,
             )
         book = cookiecutter(cc_url, output_dir=Path(path_book))
     _message_box(f"Your book template can be found at\n\n    {book}{os.sep}")

--- a/jupyter_book/directive/toc.py
+++ b/jupyter_book/directive/toc.py
@@ -18,8 +18,7 @@ class TableOfContentsNode(nodes.Element):
 
 class TableofContents(SphinxDirective):
     def run(self):
-        """ returns an array of nodes for the tableofcontents directive declaration
-        """
+        """returns an array of nodes for the tableofcontents directive declaration"""
         return [TableOfContentsNode()]
 
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "sphinxcontrib-bibtex",
         "sphinx_book_theme>=0.0.36",
         "sphinx-thebe>=0.0.6",
-        "sphinx-panels~=0.4.1",
+        "sphinx-panels~=0.5.0",
     ],
     extras_require={
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "click",
         "setuptools",
         "nbformat",
-        "nbconvert",
+        "nbconvert<6",
         "jsonschema",
         "sphinx_togglebutton",
         "sphinx-copybutton",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,6 @@ def pages(temp_with_override):
 
 @pytest.fixture()
 def cli():
-    """Provides a click.testing CliRunner object for invoking CLI commands.
-    """
+    """Provides a click.testing CliRunner object for invoking CLI commands."""
     runner = CliRunner()
     return runner

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -88,7 +88,8 @@ def test_toc_rebuild(cli, build_resources):
 
     # Not using -W because we expect warnings for pages not listed in TOC
     result = cli.invoke(
-        commands.build, [tocs.as_posix(), "--toc", toc.as_posix(), "-n"],
+        commands.build,
+        [tocs.as_posix(), "--toc", toc.as_posix(), "-n"],
     )
     html = BeautifulSoup(index_html.read_text(encoding="utf8"), "html.parser")
     tags = html.find_all("a", "reference internal")
@@ -98,7 +99,8 @@ def test_toc_rebuild(cli, build_resources):
 
     toc.write_text("- file: index\n- file: content2\n- file: content1\n")
     result = cli.invoke(
-        commands.build, [tocs.as_posix(), "--toc", toc.as_posix(), "-n"],
+        commands.build,
+        [tocs.as_posix(), "--toc", toc.as_posix(), "-n"],
     )
     assert result.exit_code == 0, result.output
     html = BeautifulSoup(index_html.read_text(encoding="utf8"), "html.parser")


### PR DESCRIPTION
This adds some quick docs to show off the new `sphinx-panels` tabbed directive 👍 it also bumps our sphinx-panels version to v0.5.0