### PR TITLE
🔧 MAINTAIN: add doc references in config/toc templates

### DIFF
--- a/jupyter_book/book_template/_config.yml
+++ b/jupyter_book/book_template/_config.yml
@@ -1,4 +1,6 @@
 # Book settings
+# Learn more at https://jupyterbook.org/customize/config.html
+#
 title: My sample book
 author: The Jupyter Book Community
 logo: logo.png

--- a/jupyter_book/book_template/_toc.yml
+++ b/jupyter_book/book_template/_toc.yml
@@ -1,3 +1,6 @@
+# Table of content
+# Learn more at https://jupyterbook.org/customize/toc.html
+#
 - file: intro
 - file: content
   sections:


### PR DESCRIPTION
In this PR I add a title and reference to the online documentation within the template files for anyone doing `jupyter-book create`. I'd like them to contain a reference to the online documentation, as it would be useful for both somewhat experienced users looking something up quickly and those that doesn't even know that the `_toc.yml` or `_config.yml` file is associated with `jupyter-book`.