### PR TITLE
📚 DOCS: justifying text (#992)

### DIFF
--- a/docs/advanced/sphinx.md
+++ b/docs/advanced/sphinx.md
@@ -131,6 +131,16 @@ The rules should then automatically be applied to your site. In general, these
 CSS and JS files will be loaded *after* others are loaded on your page, so they
 should overwrite pre-existing rules and behaviour.
 
+### An example: Justify the text
+
+If you want the text of you book to be justified instead of left aligned then create `myfile.css` under `mybook/_static` with the following CSS:
+
+```css
+p {
+    text-align: justify;
+}
+```
+
 ## Manual sphinx configuration
 
 You may also directly override the key-value pairs that Sphinx normally has


### PR DESCRIPTION
Add documentation for using justified text the book. Closes #992.

I put it as an example for modifying CSS rather than in the advanced section as suggested by @choldgraf . But I can change it if you prefer it being in the advanced section.