### PR TITLE
[ENH] Add Juniper buttons

### DIFF
--- a/docs/customize/toc.md
+++ b/docs/customize/toc.md
@@ -26,7 +26,10 @@ The Table of Contents is broadly organized like so:
   your book's content. Their paths are relative to the book's root.
 
 ```{note}
-By default, the landing page of your book will not appear in the navbar, but this can be enabled in your `_config.yml` file by setting the `home_page_in_navbar` option to `true` (under the [html section](https://jupyterbook.org/customize/config.html#configuration-reference)).
+By default, the landing page of your book will appear in the navbar, but this can be disabled in your `_config.yml` file by setting the `home_page_in_navbar` option to `false` (under the [html section](https://jupyterbook.org/customize/config.html#configuration-reference)).
+```
+
+```{note}
 Currently, it is not possible to add nested sections to your landing page (see [#844](https://github.com/executablebooks/jupyter-book/issues/844))
 ```
 

--- a/jupyter_book/config.py
+++ b/jupyter_book/config.py
@@ -28,6 +28,7 @@ def get_default_sphinx_config():
             "jupyter_book",
             "sphinxcontrib.bibtex",
             "sphinx_thebe",
+            "sphinx_juniper",
             "sphinx_comments",
             "sphinx.ext.intersphinx",
             "sphinx_panels",

--- a/jupyter_book/config_schema.json
+++ b/jupyter_book/config_schema.json
@@ -159,6 +159,12 @@
                 "thebe": {
                     "type": "boolean"
                 },
+                "juniper": {
+                    "type": [
+                        "boolean",
+                        "object"
+                    ]
+                },
                 "colab_url": {
                     "type": "string"
                 }

--- a/jupyter_book/default_config.yml
+++ b/jupyter_book/default_config.yml
@@ -58,6 +58,7 @@ launch_buttons:
   binderhub_url             : https://mybinder.org  # The URL of the BinderHub (e.g., https://mybinder.org)
   jupyterhub_url            : ""  # The URL of the JupyterHub (e.g., https://datahub.berkeley.edu)
   thebe                     : false  # Add a thebe button to pages (requires the repository to run on Binder)
+  juniper                   : false  # Add a juniper button to notebook pages
   colab_url                 : https://colab.research.google.com # The URL of Google Colab (e.g., https://colab.research.google.com)
 
 repository:

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "sphinxcontrib-bibtex",
         "sphinx_book_theme>=0.0.36",
         "sphinx-thebe>=0.0.6",
-        "sphinx-juniper>=0.0.3",
+        "sphinx-juniper>=0.0.5",
         "sphinx-panels~=0.5.0",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         "sphinxcontrib-bibtex",
         "sphinx_book_theme>=0.0.36",
         "sphinx-thebe>=0.0.6",
+        "sphinx-juniper>=0.0.3",
         "sphinx-panels~=0.5.0",
     ],
     extras_require={


### PR DESCRIPTION
If possible, I'd love to help get thebe/interactive notebooks into a production state, and since I'm slightly more familiar with @ines ' [Juniper package](https://github.com/ines/juniper) (built on Thebe), that's what I've been playing around with.

Right now I have a small sphinx extension, [sphinx-juniper](https://github.com/ashtonmv/sphinx-juniper), inspired by @choldgraf 's sphinx-thebe, that works on all rendered .ipynb files in a book:

```bash
pip install sphinx-juniper==0.0.4
```
```yaml
# _config.yml of the JB project
sphinx:
  extra_extensions:
    - sphinx_juniper
  config:
    # juniper: true   # works too, loads all defaults
    juniper:
      url: https://mybinder.org
      repo: ashtonmv/python_binder
      theme: monokai
```

![sphinx_juniper](https://user-images.githubusercontent.com/16377664/95398931-575bff00-0907-11eb-8a6b-a20d5e429bd0.gif)

I opened this PR because I think it would make more sense to configure juniper under launch_buttons with the other "interactive" triggers:

```yaml
launch_buttons:
  juniper: true
```

but I don't know how realistic it is to imagine that juniper would be added as a key to the _config.yaml here, let alone as an extension to install. If that's a stretch, or if nobody else wants to use juniper, I can of course live with the first option above. But there are a few potential advantages I could see to adding it:

- sphinx-juniper doesn't touch any HTML pages if you don't include juniper in your config file, and even then only imports the "heavyweight" JS on the pages that will use it.
- Juniper allows for cached Binder connections (although this can also cause bugs at times). Maybe thebe does too? I'm not sure.
- It puts an "Initialize Juniper" button in the launch button dropdown menu next to Colab and Mybinder, which is where I would expect something like that.