### PR TITLE
📚 DOCS: instructions for custom CSS in printing HTML PDFs

### DIFF
--- a/docs/advanced/pdf.md
+++ b/docs/advanced/pdf.md
@@ -64,6 +64,24 @@ for a potential fix, and [this Jupyter Book issue](https://github.com/executable
 where we're tracking the issue.
 :::
 
+### Control the look of PDF via HTML
+
+Because you are using HTML as an intermediary for your book's PDF, you can control the look and feel of the HTML via your own CSS rules. Most CSS changes that you make to your HTML website will also persist in the PDF version of that website. For information about how to define your own CSS rules, see [](custom-assets).
+
+To add CSS rules that **only apply to the printed PDF**, use the `@media print` CSS pattern to define print-specific rules. These will *only* be applied when the HTML is being printed, and will not show up in your non-PDF website.
+
+For example, to **hide the right table of contents** at print time, you could add this rule:
+
+```scss
+@media print {
+    .bd-toc {
+        visibility: hidden;
+    }
+}
+```
+
+The right Table of Contents would be present in your live website, but hidden when someone printed a PDF of your website.
+
 (pdf/latex)=
 ## Build a PDF using LaTeX
 

--- a/docs/advanced/sphinx.md
+++ b/docs/advanced/sphinx.md
@@ -100,6 +100,7 @@ Simple is better than complex. 😵
 ```
 ````
 
+(custom-assets)=
 ## Custom CSS or JavaScript
 
 If you'd like to include custom CSS rules or JavaScript scripts in your book,


### PR DESCRIPTION
In https://github.com/executablebooks/sphinx-book-theme/issues/222 people asked if they could remove the table of contents when printing from HTML. This documents how users can change these kinds of things via CSS rules.

closes https://github.com/executablebooks/sphinx-book-theme/issues/222