### PR TITLE
🔧 MAINTAIN: Fix example tag syntax

### DIFF
--- a/docs/file-types/myst-notebooks.md
+++ b/docs/file-types/myst-notebooks.md
@@ -146,7 +146,7 @@ cell like so:
 
 ````md
 ```{code-cell}
-:tags: tag1, tag2, tag3
+:tags: [tag1, tag2, tag3]
 your-code
 ```
 ````


### PR DESCRIPTION
I tried leaving off the square brackets and that syntax doesn't seem to work:

```
nbformat.validator.NotebookValidationError: 'remove-cell' is not of type 'array'

Failed validating 'type' in notebook['properties']['metadata']['properties']['tags']:

On instance['metadata']['tags']:
'remove-cell'
```