### PR TITLE
ENH: add label for global toctree for referencing TOC (latex)

### DIFF
--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -137,7 +137,14 @@ def add_toctree(app, docname, source):
             toc_sections.append(this_section)
 
         # Generate the TOCtree for this page
-        toctrees.append(_gen_toctree(toc_options, toc_sections, parent_suff))
+        if docname == app.config["globaltoc"]["file"]:
+            toctree = "(globaltoc)=\n" + _gen_toctree(
+                toc_options, toc_sections, parent_suff
+            )
+        else:
+            toctree = _gen_toctree(toc_options, toc_sections, parent_suff)
+        toctrees.append(toctree)
+
     toctrees = "\n".join(toctrees)
 
     # Now modify the source file with the new toctree text


### PR DESCRIPTION
This PR is looking to address https://github.com/executablebooks/meta/discussions/167#discussioncomment-113023.

It adds a `(globaltoc)=` label above the `toctree` that is generated for the `masterdoc` file. 

**Issue:** The issue is that the `toctree` is currently added to the end of the `masterdoc` in the `xml`. The label is added by the latex writer but is added at the end of whatever contents are added in the `masterdoc` so links to the bottom of `intro`/`frontmatter` rather than the `table of contents`

@choldgraf did we resolve if the `toctree` is going to be moved?