### PR TITLE
🗑 DEPRECATE: removing expand_sections for toc

### DIFF
--- a/docs/customize/toc.md
+++ b/docs/customize/toc.md
@@ -348,19 +348,6 @@ built by Jupyter Book, see [](execute/exclude).
 The following sections apply to controlling the left navigation bar in
 HTML books built with Jupyter Book.
 
-### Automatically expand subsections of a page
-
-Sometimes you'd like some subsections of your book to *always* be expanded (as opposed
-to only expanded when one of the subsections is active). To enable this, add the following key in an entry of
-your `_toc.yml` file:
-
-```yaml
-- file: path/to/your/page
-  expand_sections: true
-```
-
-All subsections of that page will now be expanded in the navigation bar.
-
 ### Add external links
 
 You can also add external links to websites that are outside of your book.

--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -64,12 +64,6 @@ def add_toctree(app, docname, source):
     if not sections:
         return
 
-    # Look for expand_sections and add to html config
-    if "expand_sections" in parent_page:
-        expanded_sections = app.config.html_theme_options.get("expand_sections", [])
-        expanded_sections.append(docname)
-        app.config.html_theme_options["expand_sections"] = expanded_sections
-
     # Rename `chapter:` in sections to `part:`
     # TODO: deprecate this after a release or two
     for isection in sections:
@@ -353,7 +347,6 @@ def _check_toc_entries(sections):
         "chapters",
         "sections",
         "title",
-        "expand_sections",
         "numbered",
     ]
     for section in sections:


### PR DESCRIPTION
This removes `expand_sections` from the documentation and code, as it is now deprecated in `sphinx-book-theme`