### PR TITLE
📚 DOCS: Updates to code-cell docs

### DIFF
--- a/docs/content/code-outputs.md
+++ b/docs/content/code-outputs.md
@@ -16,9 +16,38 @@ kernelspec:
 The formatting of code outputs is highly configurable.
 Below we give examples of how to format particular outputs and even insert outputs into other locations of the document.
 
+The [MyST cheat sheet](myst_cheatsheet) provides a [list of `code-cell` tags available](myst_cheatsheet:code-cell:tags)
+
 :::{seealso}
 The [MyST-NB documentation](myst-nb:use/format/cutomise), for how to fully customize the output renderer.
 :::
+
+(content:code-outputs:scrolling)=
+## Scrolling cell outputs
+
+The traditional Jupyter Notebook interface allows you to toggle **output scrolling**
+for your cells. This allows you to visualize part of a long output without it taking up
+the entire page.
+
+You can trigger this behavior in Jupyter Book by adding the following
+tag to a cell's metadata:
+
+```json
+{
+    "tags": [
+        "output_scroll",
+    ]
+}
+```
+
+For example, the following cell has a long output, but will be scrollable in the book:
+
+```{code-cell} ipython3
+:tags: [output_scroll]
+
+for ii in range(40):
+    print(f"this is output line {ii}")
+```
 
 (content:code-outputs:images)=
 ## Images

--- a/docs/content/layout.md
+++ b/docs/content/layout.md
@@ -135,7 +135,7 @@ Here's what the cell metadata for a margin cell looks like:
 ````
 
 `````{tabbed} MyST Text File
-For a MyST text file these tags can be added simply added to the `code-cell`
+For a MyST text file these tags can be added to the `code-cell`
 ````md
 ```{code-cell} <language>
 :tags: [margin]

--- a/docs/content/layout.md
+++ b/docs/content/layout.md
@@ -118,8 +118,10 @@ which we'll cover below.
 ### Margins with code cells
 
 You can make a code cell move to the right margin by adding `margin` to your
-cell's tags. Here's what the cell metadata for a margin cell looks like:
+cell's tags.
 
+````{tabbed} Jupyter Notebook
+Here's what the cell metadata for a margin cell looks like:
 ```json
 {
     "tags": [
@@ -127,6 +129,19 @@ cell's tags. Here's what the cell metadata for a margin cell looks like:
     ]
 }
 ```
+:::{seealso}
+[](jupyter-cell-tags)
+:::
+````
+
+`````{tabbed} MyST Text File
+For a MyST text file these tags can be added simply added to the `code-cell`
+````md
+```{code-cell} <language>
+:tags: [margin]
+```
+````
+`````
 
 For example, we'll re-display the figure above, and add a `margin` tag to the code cell.
 
@@ -138,37 +153,7 @@ make_fig(figsize=(10, 5))
 
 This can be combined with other tags like `remove-input` to **only display the figure**.
 
-:::{seealso}
-[](jupyter-cell-tags)
-:::
-
-+++
-
-## Scrolling cell outputs
-
-The traditional Jupyter Notebook interface allows you to toggle **output scrolling**
-for your cells. This allows you to visualize part of a long output without it taking up
-the entire page.
-
-You can trigger this behavior in Jupyter Book by adding the following
-tag to a cell's metadata:
-
-```json
-{
-    "tags": [
-        "output_scroll",
-    ]
-}
-```
-
-For example, the following cell has a long output, but will be scrollable in the book:
-
-```{code-cell} ipython3
-:tags: [output_scroll]
-
-for ii in range(40):
-    print(f"this is output line {ii}")
-```
+The [MyST cheat sheet](myst_cheatsheet) provides a [list of `code-cell` tags available](myst_cheatsheet:code-cell:tags)
 
 ## Full-width content
 

--- a/docs/reference/cheatsheet.md
+++ b/docs/reference/cheatsheet.md
@@ -846,6 +846,7 @@ print(note)
 
 See {doc}`../file-types/myst-notebooks` for more information.
 
+(myst_cheatsheet:code-cell:tags)=
 #### Tags
 
 The following `tags` can be applied to code cells by introducing them as options:


### PR DESCRIPTION
This PR makes some adjustment to the docs to make `output_scroll` easier to find and updates `margin` to show `tabs` for how to use it in `Jupyter Notebook` and `MyST Text File` contexts. 