### PR TITLE
📚  DOCS: Improve cross links on getting started

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -81,6 +81,8 @@ To install the `jupyter-book` pre-release from pip, run the following command:
 pip install -U jupyter-book
 ```
 
+{ref}`create-a-template-book` to get started right away, or see the [getting started guide](start/overview) for more information.
+
 (example-project)=
 ## A small example project
 

--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -205,6 +205,7 @@ There are many other interesting things that you can do with notebook content as
 This is only a simple example, and touches on just a couple of the many ways that you can configure and structure your book. For more information about this, see [](../file-types/index) as well as [](../content/content-blocks).
 :::
 
+(create-a-template-book)=
 ## Create a template book
 
 Jupyter-Book comes with a demo book so that you can see how the content files


### PR DESCRIPTION
In starting, I went straight from pip install into the example book, which was a lot to onboard into. The template `create` is much easier to get your head around. This PR just adds another few links to point you over to existing docs.

![image](https://user-images.githubusercontent.com/913249/98414542-ccbb0c80-2038-11eb-90eb-8109b46294f7.png)

I realize these are above as well, but as a user I scan for what do I install and then read the lines after that. :)