### PR TITLE
📚 DOCS: adding a title to our example tables

### DIFF
--- a/docs/content/figures.md
+++ b/docs/content/figures.md
@@ -171,7 +171,7 @@ We just have to use the title of the admonition as target:
 [Go to the fish!](markdown-fig)
 ```
 
-
+(figures:referencing)=
 ## Referencing figures
 
 You can then refer to your figures by using the `{ref}` role or Markdown style references like:
@@ -186,6 +186,7 @@ which will replace the reference with the figure caption like so:
 - {ref}`directive-fig`
 - [](markdown-fig)
 
+(figures:numref)=
 ### Numbered references
 
 Another convenient way to create cross-references is with the `{numref}` role,

--- a/docs/reference/cheatsheet.md
+++ b/docs/reference/cheatsheet.md
@@ -329,7 +329,7 @@ Another alternative is to use Markdown syntax:
       - 2744
     ```
     ````
-  - ```{list-table}
+  - ```{list-table} My table title
     :header-rows: 1
     :name: example-table
 
@@ -341,7 +341,7 @@ Another alternative is to use Markdown syntax:
       - 2744
     ```
 * - ````md
-     ```{list-table} title
+     ```{list-table} Table title
     :header-rows: 1
 
     * - Col1
@@ -353,7 +353,7 @@ Another alternative is to use Markdown syntax:
     ```
     ````
   - ````md
-     ```{list-table} Table with a title
+     ```{list-table} This table title
     :header-rows: 1
 
     * - Training
@@ -364,7 +364,7 @@ Another alternative is to use Markdown syntax:
       - 2744
     ```
     ````
-  - ```{list-table} Table with a title
+  - ```{list-table} This table title
     :header-rows: 1
 
     * - Training
@@ -379,7 +379,10 @@ Another alternative is to use Markdown syntax:
 ### Referencing tables
 
 ```{note}
-To add a label to your table simply include a `:name:` parameter followed by the label of your table. See example above.
+In order to [reference a table](figures:referencing) you must add a label to it.
+To add a label to your table simply include a `:name:` parameter followed by the label of your table.
+In order to add a [numbered reference](figures:numref), you
+must also include a table title. See example above.
 ```
 
 ``````{list-table}

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     install_requires=[
         "pyyaml",
         "docutils>=0.15",
-        "sphinx>=2,<3.3",
+        "sphinx>=2,<4",
         "myst-nb~=0.10.1",
         "click",
         "setuptools",

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     install_requires=[
         "pyyaml",
         "docutils>=0.15",
-        "sphinx>=2,<4",
+        "sphinx>=2,<3.3",
         "myst-nb~=0.10.1",
         "click",
         "setuptools",


### PR DESCRIPTION
The upgrade to Sphinx 3.3 seems to introduce some kind of table numbering bug that is causing our docs to throw a warning (and thus error). I've got an issue open about it here:

https://github.com/sphinx-doc/sphinx/issues/8360

But can't figure out what's going on. As a precaution and to keep the tests happy, ~this pins to <3.3 until we figure out what's up. @chrisjsewell does that seem reasonable to you, or too extreme?~

EDIT: this PR now adds a title to our example tables, because @najuzilu is a badass and figured out that this was the issue. I guess technically referencing a table with a `numref` was not supposed to be possible without a title for the table.

