### PR TITLE
📚 DOCS: Update gh-pages.md for hosting

### DIFF
--- a/docs/publish/gh-pages.md
+++ b/docs/publish/gh-pages.md
@@ -29,12 +29,10 @@ files in your book's `_build/html` folder.
    ```
 2. Update the settings for your GitHub pages site:
 
-    a. Use the `gh-pages` branch to host
-your website. 
+    a. Use the `gh-pages` branch to host your website.
 
-    b. Choose root directory `/` if you're
-building the book in it's own repository. Choose `/docs` 
-directory if you're building documentation with jupyter-book. 
+    b. Choose root directory `/` if you're building the book in it's own repository.
+       Choose `/docs` directory if you're building documentation with jupyter-book.
 
 3. From the `master` branch of your book's root directory (which should contain the `_build/html` folder) call `ghp-import` and point it to your HTML files, like so:
 

--- a/docs/publish/gh-pages.md
+++ b/docs/publish/gh-pages.md
@@ -27,8 +27,16 @@ files in your book's `_build/html` folder.
    ```bash
    pip install ghp-import
    ```
+2. Update the settings for your GitHub pages site:
 
-2. From the `master` branch of your book's root directory (which should contain the `_build/html` folder) call `ghp-import` and point it to your HTML files, like so:
+    a. Use the `gh-pages` branch to host
+your website. 
+
+    b. Choose root directory `/` if you're
+building the book in it's own repository. Choose `/docs` 
+directory if you're building documentation with jupyter-book. 
+
+3. From the `master` branch of your book's root directory (which should contain the `_build/html` folder) call `ghp-import` and point it to your HTML files, like so:
 
    ```bash
    ghp-import -n -p -f _build/html


### PR DESCRIPTION
I'm suggesting an added step to hosting the gh-pages site. When I first tried, I didn't understand what ghp-import was doing. It's clear from the current docs that the gh-pages branch is ephemeral, but new users will find it easier to get started with clear instructions for gh-pages settings.