### PR TITLE
ENH: Enable local_extensions to be specified in _config.yml

### DIFF
--- a/docs/advanced/sphinx.md
+++ b/docs/advanced/sphinx.md
@@ -137,46 +137,8 @@ int main() {
 
 ### Local Sphinx Extensions
 
-[Sphinx is able to use local extensions](https://www.sphinx-doc.org/en/master/development/tutorials/helloworld.html#using-the-extension) by adding additional directories to the [Python path](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH). At present, this functionality is not available within Jupyter Book.
-
-However, you can use a local Sphinx extension by using `pip` and installing the package locally. Below we'll document how you can create a local `pip`-installable Sphinx extension.
-
-First, write a minimal `setup.py` as follows:
-
-```python
-from setuptools import setup
-
-setup(
-	name='my_sphinx_ext'
-)
-```
-
-```{seealso}
-For further documentation on the purposes and configuration of `setup.py`, please refer to [the official Python documentation on setup scripts](https://docs.python.org/3/distutils/setupscript.html).
-```
-
-Next, create a new directory with your extension's name (in this case `my_sphinx_ext`) within the same directory as `setup.py`. Afterwards, create an *empty* file called `__init__.py` within this directory. If you are on Linux, simply `touch my_sphinx_ext/__init__.py`. The result should be:
-
-```
-setup.py
-my_sphinx_ext/
-└──__init__.py
-```
-
-Then, execute `pip install -e .` within the directory containing `setup.py`. This will install `my_sphinx_ext` as a local Python package.
-
-It's then as easy as updating your `_config.yml` with your new extension:
-
-```yaml
-  sphinx:
-    extra_extensions:
-    - my_sphinx_ext
-```
-
-
-:::{admonition,tip} More information on creating Sphinx extensions
-The extension in this example is `pip`-installable, but does nothing! For more information about how to create your own Sphinx extension, try following [Sphinx's extension tutorials](https://www.sphinx-doc.org/en/master/development/tutorials/index.html).
-:::
+[Sphinx is able to use local extensions](https://www.sphinx-doc.org/en/master/development/tutorials/helloworld.html#using-the-extension) by adding additional directories to the [Python path](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH). You can use local extensions by
+specifying them as [local_extensions](config:sphinx:local_extensions) in the `_config.yml` file.
 
 (custom-assets)=
 ## Custom CSS or JavaScript

--- a/docs/customize/config.md
+++ b/docs/customize/config.md
@@ -123,16 +123,17 @@ This will **append** to the list of extensions already loaded by Jupyter Book.
 
 ### Adding Local Extensions
 
-To add a local extension that requires a path, use:
+To add a local extension you can specify the path using `local_paths` such as:
 
 ```yaml
 sphinx:
-  local_extensions:
-    <name>: <path>
+  extra_extensions: [my_extension]
+  local_paths:
+    - <path>
 ```
 
-This will **append to the list of extensions already loaded by Jupyter Book and update the `sys.path` so
-the local extension can be found.
+This will **append** the path to the `sys.path` context so the local extension
+can be found.
 
 ### Specifying Sphinx Configuration Values
 

--- a/docs/customize/config.md
+++ b/docs/customize/config.md
@@ -123,17 +123,16 @@ This will **append** to the list of extensions already loaded by Jupyter Book.
 
 ### Adding Local Extensions
 
-To add a local extension you can specify the path using `local_paths` such as:
+To add a local extension that requires a path, use:
 
 ```yaml
 sphinx:
-  extra_extensions: [my_extension]
-  local_paths:
-    - <path>
+  local_extensions:
+    <name>: <path>
 ```
 
-This will **append** the path to the `sys.path` context so the local extension
-can be found.
+This will **append to the list of extensions already loaded by Jupyter Book and update the `sys.path` so
+the local extension can be found.
 
 ### Specifying Sphinx Configuration Values
 

--- a/docs/customize/config.md
+++ b/docs/customize/config.md
@@ -110,6 +110,7 @@ html:
 
 Users who are familiar with [Sphinx configuration](sphinx:build-config) may wish to directly add extensions or set options to parse to the underlying Sphinx application.
 
+(config:sphinx:extra_extensions)=
 ### Adding Extra Extensions
 
 To add extensions, use:
@@ -121,6 +122,7 @@ sphinx:
 
 This will **append** to the list of extensions already loaded by Jupyter Book.
 
+(config:sphinx:local_extensions)=
 ### Adding Local Extensions
 
 To add a local extension that requires a path, use:

--- a/docs/customize/config.md
+++ b/docs/customize/config.md
@@ -106,9 +106,11 @@ html:
 ```
 
 (config:sphinx)=
-### Advanced configuration (with sphinx)
+## Advanced configuration (with sphinx)
 
 Users who are familiar with [Sphinx configuration](sphinx:build-config) may wish to directly add extensions or set options to parse to the underlying Sphinx application.
+
+### Adding Extra Extensions
 
 To add extensions, use:
 
@@ -118,6 +120,21 @@ sphinx:
 ```
 
 This will **append** to the list of extensions already loaded by Jupyter Book.
+
+### Adding Local Extensions
+
+To add a local extension that requires a path, use:
+
+```yaml
+sphinx:
+  local_extensions:
+    <name>: <path>
+```
+
+This will **append to the list of extensions already loaded by Jupyter Book and update the `sys.path` so
+the local extension can be found.
+
+### Specifying Sphinx Configuration Values
 
 To set additional Sphinx configurations:
 

--- a/jupyter_book/config.py
+++ b/jupyter_book/config.py
@@ -6,6 +6,8 @@ from typing import Optional, Union
 
 import jsonschema
 import yaml
+import sys
+import os
 
 from .utils import _message_box
 
@@ -282,6 +284,16 @@ def yaml_to_sphinx(yaml: dict):
         for extension in extra_extensions:
             if extension not in sphinx_config["extensions"]:
                 sphinx_config["extensions"].append(extension)
+
+    local_extensions = yaml.get("sphinx", {}).get("local_extensions")
+    if local_extensions:
+        if "extensions" not in sphinx_config:
+            sphinx_config["extensions"] = get_default_sphinx_config()["extensions"]
+        for extension, path in local_extensions.items():
+            if extension not in sphinx_config["extensions"]:
+                sphinx_config["extensions"].append(extension)
+            if path not in sys.path:
+                sys.path.append(os.path.abspath(path))
 
     # items in sphinx.config will override defaults,
     # rather than recursively updating them

--- a/jupyter_book/config.py
+++ b/jupyter_book/config.py
@@ -285,9 +285,13 @@ def yaml_to_sphinx(yaml: dict):
             if extension not in sphinx_config["extensions"]:
                 sphinx_config["extensions"].append(extension)
 
-    local_paths = yaml.get("sphinx", {}).get("local_paths")
-    if local_paths:
-        for path in local_paths:
+    local_extensions = yaml.get("sphinx", {}).get("local_extensions")
+    if local_extensions:
+        if "extensions" not in sphinx_config:
+            sphinx_config["extensions"] = get_default_sphinx_config()["extensions"]
+        for extension, path in local_extensions.items():
+            if extension not in sphinx_config["extensions"]:
+                sphinx_config["extensions"].append(extension)
             if path not in sys.path:
                 sys.path.append(os.path.abspath(path))
 

--- a/jupyter_book/config.py
+++ b/jupyter_book/config.py
@@ -285,13 +285,9 @@ def yaml_to_sphinx(yaml: dict):
             if extension not in sphinx_config["extensions"]:
                 sphinx_config["extensions"].append(extension)
 
-    local_extensions = yaml.get("sphinx", {}).get("local_extensions")
-    if local_extensions:
-        if "extensions" not in sphinx_config:
-            sphinx_config["extensions"] = get_default_sphinx_config()["extensions"]
-        for extension, path in local_extensions.items():
-            if extension not in sphinx_config["extensions"]:
-                sphinx_config["extensions"].append(extension)
+    local_paths = yaml.get("sphinx", {}).get("local_paths")
+    if local_paths:
+        for path in local_paths:
             if path not in sys.path:
                 sys.path.append(os.path.abspath(path))
 

--- a/jupyter_book/config_schema.json
+++ b/jupyter_book/config_schema.json
@@ -190,11 +190,14 @@
                         "type": "string"
                     }
                 },
-                "local_extensions": {
+                "local_paths": {
                     "type": [
                         "null",
-                        "object"
-                    ]
+                        "array"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "config": {
                     "type": [

--- a/jupyter_book/config_schema.json
+++ b/jupyter_book/config_schema.json
@@ -190,6 +190,12 @@
                         "type": "string"
                     }
                 },
+                "local_extensions": {
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
                 "config": {
                     "type": [
                         "null",

--- a/jupyter_book/config_schema.json
+++ b/jupyter_book/config_schema.json
@@ -190,14 +190,11 @@
                         "type": "string"
                     }
                 },
-                "local_paths": {
+                "local_extensions": {
                     "type": [
                         "null",
-                        "array"
-                    ],
-                    "items": {
-                        "type": "string"
-                    }
+                        "object"
+                    ]
                 },
                 "config": {
                     "type": [

--- a/jupyter_book/default_config.yml
+++ b/jupyter_book/default_config.yml
@@ -69,5 +69,5 @@ repository:
 # Advanced and power-user settings
 sphinx:
   extra_extensions          :   # A list of extra extensions to load by Sphinx (added to those already used by JB).
-  local_paths               :   # A list of paths to be added to sys.path for loading local extensions
+  local_extensions          :   # A list of local extensions to load by sphinx specified by "name: path" items
   config                    :   # key-value pairs to directly over-ride the Sphinx configuration

--- a/jupyter_book/default_config.yml
+++ b/jupyter_book/default_config.yml
@@ -69,5 +69,5 @@ repository:
 # Advanced and power-user settings
 sphinx:
   extra_extensions          :   # A list of extra extensions to load by Sphinx (added to those already used by JB).
-  local_extensions          :   # A list of local extensions to load by sphinx specified by "name: path" items
+  local_paths               :   # A list of paths to be added to sys.path for loading local extensions
   config                    :   # key-value pairs to directly over-ride the Sphinx configuration

--- a/jupyter_book/default_config.yml
+++ b/jupyter_book/default_config.yml
@@ -69,5 +69,5 @@ repository:
 # Advanced and power-user settings
 sphinx:
   extra_extensions          :   # A list of extra extensions to load by Sphinx (added to those already used by JB).
-  local_extensions          :   # A list of local extensions to load by sphinx ([Tuple(name, path)])
+  local_extensions          :   # A list of local extensions to load by sphinx specified by "name: path" items
   config                    :   # key-value pairs to directly over-ride the Sphinx configuration

--- a/jupyter_book/default_config.yml
+++ b/jupyter_book/default_config.yml
@@ -69,4 +69,5 @@ repository:
 # Advanced and power-user settings
 sphinx:
   extra_extensions          :   # A list of extra extensions to load by Sphinx (added to those already used by JB).
+  local_extensions          :   # A list of local extensions to load by sphinx ([Tuple(name, path)])
   config                    :   # key-value pairs to directly over-ride the Sphinx configuration

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,7 @@ from jupyter_book.commands import sphinx
         {
             "sphinx": {
                 "extra_extensions": ["other"],
+                "local_extensions": {"helloworld": "./ext"},
                 "config": {
                     "html_theme_options": {
                         "launch_buttons": {"binderhub_url": "other"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,8 +19,8 @@ from jupyter_book.commands import sphinx
         {"exclude_patterns": ["new"]},
         {
             "sphinx": {
-                "extra_extensions": ["other"],
-                "local_extensions": {"helloworld": "./ext"},
+                "extra_extensions": ["other", "helloworld"],
+                "local_paths": ["./ext"],
                 "config": {
                     "html_theme_options": {
                         "launch_buttons": {"binderhub_url": "other"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,8 +19,8 @@ from jupyter_book.commands import sphinx
         {"exclude_patterns": ["new"]},
         {
             "sphinx": {
-                "extra_extensions": ["other", "helloworld"],
-                "local_paths": ["./ext"],
+                "extra_extensions": ["other"],
+                "local_extensions": {"helloworld": "./ext"},
                 "config": {
                     "html_theme_options": {
                         "launch_buttons": {"binderhub_url": "other"}

--- a/tests/test_config/test_get_final_config_sphinx_.yml
+++ b/tests/test_config/test_get_final_config_sphinx_.yml
@@ -8,8 +8,9 @@ _user_config:
       new: value
     extra_extensions:
     - other
-    local_extensions:
-      helloworld: ./ext
+    - helloworld
+    local_paths:
+    - ./ext
 final:
   author: The Jupyter Book community
   comments_config:

--- a/tests/test_config/test_get_final_config_sphinx_.yml
+++ b/tests/test_config/test_get_final_config_sphinx_.yml
@@ -8,9 +8,8 @@ _user_config:
       new: value
     extra_extensions:
     - other
-    - helloworld
-    local_paths:
-    - ./ext
+    local_extensions:
+      helloworld: ./ext
 final:
   author: The Jupyter Book community
   comments_config:

--- a/tests/test_config/test_get_final_config_sphinx_.yml
+++ b/tests/test_config/test_get_final_config_sphinx_.yml
@@ -8,6 +8,8 @@ _user_config:
       new: value
     extra_extensions:
     - other
+    local_extensions:
+      helloworld: ./ext
 final:
   author: The Jupyter Book community
   comments_config:
@@ -35,6 +37,7 @@ final:
   - sphinx_panels
   - sphinx_book_theme
   - other
+  - helloworld
   html_add_permalinks: ¶
   html_baseurl: ''
   html_favicon: ''


### PR DESCRIPTION
fixes #1055

This PR adds `local_extensions` as a component of the `sphinx` configuration to specify local extensions as `name: path` pairs. 

**Usage:**

```yaml
sphinx:
  local_extensions:
    helloworld: ./ext
```

`helloworld` is added to `sphinx_config['extensions']` and the `sys.path` is updated with the path variable. 