### PR TITLE
🐛 FIX: Check for file extensions when generating toc

### DIFF
--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -214,7 +214,7 @@ def _gen_toctree(options, subsections, parent_suff):
     elif parent_suff == ".rst":
         toctree_template = toctree_text_rst
     else:
-        return ''
+        return ""
 
     # Create the markdown directive for our toctree
     toctree = dedent(toctree_template).format(

--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -131,7 +131,8 @@ def add_toctree(app, docname, source):
             toc_sections.append(this_section)
 
         # Generate the TOCtree for this page
-        toctrees.append(_gen_toctree(toc_options, toc_sections, parent_suff))
+        if parent_suff in [".ipynb", ".md", ".rst"]:
+            toctrees.append(_gen_toctree(toc_options, toc_sections, parent_suff))
     toctrees = "\n".join(toctrees)
 
     # Now modify the source file with the new toctree text

--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -131,8 +131,7 @@ def add_toctree(app, docname, source):
             toc_sections.append(this_section)
 
         # Generate the TOCtree for this page
-        if parent_suff in [".ipynb", ".md", ".rst"]:
-            toctrees.append(_gen_toctree(toc_options, toc_sections, parent_suff))
+        toctrees.append(_gen_toctree(toc_options, toc_sections, parent_suff))
     toctrees = "\n".join(toctrees)
 
     # Now modify the source file with the new toctree text
@@ -214,6 +213,8 @@ def _gen_toctree(options, subsections, parent_suff):
         toctree_template = toctree_text_md
     elif parent_suff == ".rst":
         toctree_template = toctree_text_rst
+    else:
+        return ''
 
     # Create the markdown directive for our toctree
     toctree = dedent(toctree_template).format(


### PR DESCRIPTION
`_gen_toctree` function was throwing variable error before we could reach this error  https://github.com/executablebooks/jupyter-book/blob/master/jupyter_book/toc.py#L149

A small check to prevent that. 

fixes https://github.com/executablebooks/jupyter-book/issues/1104