### PR TITLE
📚 DOCS: Remove extra quotation mark

### DIFF
--- a/docs/reference/cheatsheet.md
+++ b/docs/reference/cheatsheet.md
@@ -886,11 +886,11 @@ The following `tags` can be applied to code cells by introducing them as options
     print("This is a test.")
     ```
     ````
-* - `"hide-input""`
+* - `"hide-input"`
   - Hide cell but the display the outputs
   - ````md
     ```{code-cell} ipython3
-    :tags: ["hide-input""]
+    :tags: ["hide-input"]
     print("This is a test.")
     ```
     ````


### PR DESCRIPTION
There are two quotation marks that appear https://jupyterbook.org/reference/cheatsheet.html#tags: `"hide-input""` should in fact be: `"hide-input"`