### PR TITLE
🔧 MAINT: pin sphinxcontrib-bibtex

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "sphinx_togglebutton",
         "sphinx-copybutton",
         "sphinx-comments",
-        "sphinxcontrib-bibtex",
+        "sphinxcontrib-bibtex~=1.0.0",
         "sphinx_book_theme>=0.0.39",
         "sphinx-thebe>=0.0.6",
         "sphinx-panels~=0.5.2",


### PR DESCRIPTION
the sphinxcontrib-bibtex extension just released 2.0 that introduced some incompatibility, so this pins to 1.0 until we can figure out how to gracefully upgrade