### PR TITLE
🚀 RELEASE: v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.9.1 2020-12-22
+
+This is a minor release to issue `v0.9` to PyPI and updates a broken link that prohibited the `v0.9.0` PyPI release action.
+
 ## v0.9.0 2020-12-09
 
 ([full changelog](https://github.com/executablebooks/jupyter-book/compare/v0.8.3...6c30f554d86fe7d1a0e4ad05012a5de4133117d0))

--- a/jupyter_book/__init__.py
+++ b/jupyter_book/__init__.py
@@ -5,7 +5,7 @@ from .toc import add_toc_to_sphinx, add_toctree
 from .directive.toc import TableofContents, SwapTableOfContents
 
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 
 def add_static_files(app, config):


### PR DESCRIPTION
This is a minor release to fix an issue with the release of `jupyter-book==v0.9.0` via PyPI due to a test build warning once #1129 was merged. 