### PR TITLE
fixing mtime bug

### DIFF
--- a/jupyter_book/commands/__init__.py
+++ b/jupyter_book/commands/__init__.py
@@ -228,9 +228,10 @@ def build(
             )
 
         # Check whether the table of contents has changed. If so we rebuild all
-        if toc and BUILD_PATH.joinpath(".doctrees").exists():
+        build_files = list(BUILD_PATH.joinpath(".doctrees").rglob("*"))
+        if toc and build_files:
             toc_modified = toc.stat().st_mtime
-            build_files = BUILD_PATH.rglob(".doctrees/*")
+
             build_modified = max([os.stat(ii).st_mtime for ii in build_files])
 
             # If the toc file has been modified after the build we need to force rebuild


### PR DESCRIPTION
This fixes a bug where `.doctrees` exists, but is empty, and so our check for its existence passes but then fails when we try to take the `max` of an empty sequence. I am not sure why this bug isn't popping up in our tests, it only seems to occur under certain circumstances (maybe related to windows operating system?). But I think this will fix it.

closes #1142 