### PR TITLE
IMPROVE: set TOC numbering depth via the `numbered` flag

### DIFF
--- a/docs/customize/toc.md
+++ b/docs/customize/toc.md
@@ -164,6 +164,7 @@ your introduction page entry (the first entry in `_toc.yml`). For example:
 This will cause all chapters of the book to be
 numbered. They will follow a hierarchy according to the sub-sections structure
 defined in your `_toc.yml` file.
+You can also limit the TOC numbering depth by setting the `numbered` flag to an integer instead of `true`, e.g., `numbered: 3`.
 
 If you'd like to number **subsets of chapters**, group them into parts and
 apply the `numbered: true` flag to the parts whose chapters you wish to be numbered.

--- a/docs/customize/toc.md
+++ b/docs/customize/toc.md
@@ -164,7 +164,7 @@ your introduction page entry (the first entry in `_toc.yml`). For example:
 This will cause all chapters of the book to be
 numbered. They will follow a hierarchy according to the sub-sections structure
 defined in your `_toc.yml` file.
-You can also limit the TOC numbering depth by setting the `numbered` flag to an integer instead of `true`, e.g., `numbered: 3`.
+You can also **limit the TOC numbering depth** by setting the `numbered` flag to an integer instead of `true`, e.g., `numbered: 3`.
 
 If you'd like to number **subsets of chapters**, group them into parts and
 apply the `numbered: true` flag to the parts whose chapters you wish to be numbered.

--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -96,8 +96,20 @@ def add_toctree(app, docname, source):
     for isection in sections:
         # Check for TOC options (that generally only change behavior on top-level page)
         toc_options = {}
-        if isection.get("numbered") or parent_page.get("numbered"):
+
+        # Child numbering setting overwrites parent numbering setting
+        if "numbered" in isection:
+            toc_num_depth = isection["numbered"]
+        elif "numbered" in parent_page:
+            toc_num_depth = parent_page["numbered"]
+        else:
+            toc_num_depth = False
+        # Set the toc numbering depth
+        if isinstance(toc_num_depth, int) and toc_num_depth > 0:
+            toc_options["numbered"] = toc_num_depth  # Set numbering depth
+        elif toc_num_depth:
             toc_options["numbered"] = ""  # Empty string will == a flag in the toctree
+
         if isection.get("part"):
             toc_options["caption"] = isection.get("part")
 

--- a/tests/books/toc/_toc_numbered_depth.yml
+++ b/tests/books/toc/_toc_numbered_depth.yml
@@ -1,0 +1,15 @@
+- file: index
+  title: Toc
+  numbered: 1
+  chapters:
+  - file: content1
+    title: Content1
+  - file: subfolder/index
+    title: Subfolder
+    sections:
+    - file: subfolder/asubpage
+      title: Asubpage
+- file: content2
+  title: Content2
+- file: content3
+  title: Content3

--- a/tests/books/toc/_toc_numbered_depth_parts_subset.yml
+++ b/tests/books/toc/_toc_numbered_depth_parts_subset.yml
@@ -1,0 +1,21 @@
+- file: index
+  title: Toc
+- part: Chapter 1
+  numbered: true
+  chapters:
+  - file: content1
+    title: Content1
+- part: Chapter 2
+  chapters:
+  - file: content2
+    title: Content2
+  - file: content3
+    title: Content3
+- part: Chapter 3
+  numbered: 1
+  chapters:
+  - file: subfolder/index
+    title: Subfolder
+    sections:
+    - file: subfolder/asubpage
+      title: Asubpage

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -53,8 +53,10 @@ def test_toc_numbered(cli: CliRunner, temp_with_override, file_regression):
     path_output = temp_with_override.joinpath("mybook").absolute()
     toc_list = [
         "_toc_numbered.yml",  # Numbered in top-level title
+        "_toc_numbered_depth.yml",  # Numbering limited to depth 1
         "_toc_numbered_parts.yml",  # Numbered in top-level title w/ parts
         "_toc_numbered_parts_subset.yml",  # Only some sections numbered
+        "_toc_numbered_depth_parts_subset.yml",  # Selected numbering limited to depth 1
     ]
     for itoc in toc_list:
         # Numbering with files

--- a/tests/test_toc/_toc_numbered_depth.html
+++ b/tests/test_toc/_toc_numbered_depth.html
@@ -1,0 +1,40 @@
+<nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
+<ul class="nav sidenav_l1">
+<li class="toctree-l1 current active">
+<a class="reference internal" href="#">
+   Main index
+  </a>
+</li>
+</ul>
+<ul class="nav sidenav_l1">
+<li class="toctree-l1">
+<a class="reference internal" href="content1.html">
+   1. Content1
+  </a>
+</li>
+<li class="toctree-l1 collapsible-parent">
+<a class="reference internal" href="subfolder/index.html">
+   2. Subfolder
+  </a>
+<ul class="collapse-ul">
+<li class="toctree-l2">
+<a class="reference internal" href="subfolder/asubpage.html">
+     Asubpage
+    </a>
+</li>
+</ul>
+<i class="fas fa-chevron-down">
+</i>
+</li>
+<li class="toctree-l1">
+<a class="reference internal" href="content2.html">
+   3. Content2
+  </a>
+</li>
+<li class="toctree-l1">
+<a class="reference internal" href="content3.html">
+   4. Content3
+  </a>
+</li>
+</ul>
+</nav>

--- a/tests/test_toc/_toc_numbered_depth_parts_subset.html
+++ b/tests/test_toc/_toc_numbered_depth_parts_subset.html
@@ -1,0 +1,59 @@
+<nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
+<ul class="nav sidenav_l1">
+<li class="toctree-l1 current active">
+<a class="reference internal" href="#">
+   Main index
+  </a>
+</li>
+</ul>
+<p class="caption collapsible-parent">
+<span class="caption-text">
+  Chapter 1
+ </span>
+</p>
+<ul class="nav sidenav_l1">
+<li class="toctree-l1">
+<a class="reference internal" href="content1.html">
+   1. Content1
+  </a>
+</li>
+</ul>
+<p class="caption collapsible-parent">
+<span class="caption-text">
+  Chapter 2
+ </span>
+</p>
+<ul class="nav sidenav_l1">
+<li class="toctree-l1">
+<a class="reference internal" href="content2.html">
+   Content2
+  </a>
+</li>
+<li class="toctree-l1">
+<a class="reference internal" href="content3.html">
+   Content3
+  </a>
+</li>
+</ul>
+<p class="caption collapsible-parent">
+<span class="caption-text">
+  Chapter 3
+ </span>
+</p>
+<ul class="nav sidenav_l1">
+<li class="toctree-l1 collapsible-parent">
+<a class="reference internal" href="subfolder/index.html">
+   1. Subfolder
+  </a>
+<ul class="collapse-ul">
+<li class="toctree-l2">
+<a class="reference internal" href="subfolder/asubpage.html">
+     Asubpage
+    </a>
+</li>
+</ul>
+<i class="fas fa-chevron-down">
+</i>
+</li>
+</ul>
+</nav>


### PR DESCRIPTION
Sphinx allows setting section numbering depth via the `numbered` flag, e.g., `:numbered: 3` ([see here](https://www.sphinx-doc.org/en/1.4.9/markup/toctree.html)). This PR ports such functionality to Jupyter Book, e.g.:
```yaml
- file: index
  numbered: 1
  chapters:
  - file: content1
  - file: content2
    sections:
    - file: content2-1
    - file: content2-2
- file: content3
```

This PR should resolve executablebooks/meta#113 discussion.