### PR TITLE
📚 DOCS: Fix config for setting sphinx language

### DIFF
--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -269,7 +269,7 @@ Language can be configured by providing the appropriate [language code](https://
 
 ```yaml
 sphinx:
-  config
+  config:
     language: en
 ```
 

--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -269,7 +269,8 @@ Language can be configured by providing the appropriate [language code](https://
 
 ```yaml
 sphinx:
-  language: en
+  config
+    language: en
 ```
 
 This example will set the book language to English, which would be represented in your book's HTML as `<html lang="en">...</html>`.


### PR DESCRIPTION
I have just discovered jupyter-book (kudos to the developers!) and I was following the documentation when I realised there was a problem with the code for setting the book's language.

The provided code:

```yaml
sphinx:
  language: en
```
Does not work. (no `<html lang="en">...</html>` code is added to built book). 
If I am not wrong from https://jupyterbook.org/customize/config.html?highlight=sphinx%20config#advanced-configuration-with-sphinx , the correct code should have been:


```yaml
sphinx:
  config:
    language: en
```
I've tested it locally and the `<html lang="en">...</html>` is now added.