### PR TITLE
🐛 FIX: Ensure sorting of files during toc creation

### DIFF
--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -262,7 +262,7 @@ def _find_content_structure(
 
     # First parse all the content files
     content_files = [
-        ii for ii in path.iterdir() if ii.suffix in SUPPORTED_FILE_SUFFIXES
+        ii for ii in sorted(path.iterdir()) if ii.suffix in SUPPORTED_FILE_SUFFIXES
     ]
 
     if len(content_files) == 0:


### PR DESCRIPTION
Hi,

I had an issue that during toc creation with `jupyter-book toc`, files were sometimes not sorted alphanumerically. This change fixes this.

I think while `iterdir()` returns sorted entries most of the time, this is not guaranteed.

Thanks for this excellent package!

Johannes