### PR TITLE
🛠 MAINTAIN: Fix typo in default_config.yml

### DIFF
--- a/jupyter_book/default_config.yml
+++ b/jupyter_book/default_config.yml
@@ -18,7 +18,7 @@ only_build_toc_files        : false
 # Execution settings
 execute:
   execute_notebooks         : auto  # Whether to execute notebooks at build time. Must be one of ("auto", "force", "cache", "off")
-  cache                     : ""    # A path to the jupyter cache that will be used to store execution artifacs. Defaults to `_build/.jupyter_cache/`
+  cache                     : ""    # A path to the jupyter cache that will be used to store execution artifacts. Defaults to `_build/.jupyter_cache/`
   exclude_patterns          : []    # A list of patterns to *skip* in execution (e.g. a notebook that takes a really long time)
   timeout                   : 30    # The maximum time (in seconds) each notebook cell is allowed to run.
   run_in_temp               : false # If `True`, then a temporary directory will be created and used as the command working directory (cwd),


### PR DESCRIPTION
Hello there,
A tiny pull request to fix this orthographic typo: artifacs => artifacts
See https://en.wiktionary.org/wiki/artifact