### PR TITLE
DOCS: more info on references.bib file

### DIFF
--- a/docs/content/citations.md
+++ b/docs/content/citations.md
@@ -303,7 +303,15 @@ This functionality uses the excellent [sphinxcontrib-bibtex](https://sphinxcontr
 
    This will generate the bibliography of all citations in your book. See
    [the bibliography at the end of this page](citations/bibliography) for an example.
-
+   
+   If your `.bib` file is located in another folder, you might 
+   have to specify its relative path as:
+   
+   ````md
+   ```{bibliography} ../references.bib
+   ```
+   ````
+   
 When your book is built, the bibliography and citations will now be included.
 
 :::{seealso}


### PR DESCRIPTION
The docs way of doing things did not work for me. Googling for the `reference not found` error led me to https://github.com/executablebooks/jupyter-book/issues/528, where for some reason the OP added the path to the ref file. This was also needed in my case.

What's unclear to me is why the entry in `_config.yml` is needed, so this might hide some other bug.