### PR TITLE
📚 DOCS: Add a citation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/executablebooks/jupyter-book.svg?style=svg)](https://circleci.com/gh/executablebooks/jupyter-book)
 [![codecov](https://codecov.io/gh/executablebooks/jupyter-book/branch/master/graph/badge.svg)](https://codecov.io/gh/executablebooks/jupyter-book)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2799972.svg)](https://doi.org/10.5281/zenodo.2799972)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2561065.svg)](https://doi.org/10.5281/zenodo.2561065)
 [![PyPI][pypi-badge]][pypi-link]
 
 Jupyter Book is an open-source tool for building publication-quality books and documents from computational material.

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -55,5 +55,6 @@
   - file: reference/cheatsheet
   - file: reference/cli
   - file: reference/glossary
+  - file: cite
   - file: reference/_changelog
     title: Change log

--- a/docs/cite.md
+++ b/docs/cite.md
@@ -1,0 +1,15 @@
+# Cite Jupyter Book
+
+Jupyter Book is developed by many people across academia and industry.
+Moreover, Jupyter Book is powered by an ecosystem of open source tools, most notably within the [Executable Books Project](https://executablebook.org).
+
+Rather than citing each tool, we choose to use a single blanket citation for the entire project and all of its community members.
+
+To cite Jupyter Book in publications, please use the following Zenodo reference:
+
+```{only} html
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2561065.svg)](https://doi.org/10.5281/zenodo.2561065)
+```
+
+The full author list is available by viewing the [contributors graph on GitHub](https://github.com/executablebooks/jupyter-book/graphs/contributors).
+To get the full picture, you should look at this for all projects within [the Executable Books organization](https://github.com/executablebooks).

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,5 +1,9 @@
 # Books with Jupyter
 
+```{only} html
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2561065.svg)](https://doi.org/10.5281/zenodo.2561065)
+```
+
 Jupyter Book is an open source project for building beautiful,
 publication-quality books and documents from computational material.
 


### PR DESCRIPTION
This adds a formal suggestion for how people can cite Jupyter Book (and I've also updated our Zenodo item).

- Updates the Zenodo DOI to point to the "generic" one for our project, so it will remain constant through new versions
- Adds a badge to `intro.md`
- Adds a `cite` page

cc @executablebooks/ebpteam in case anyone disagrees with this method of suggesting citations!