### PR TITLE
🔧 MAINTAIN: Expand jupytext version pinning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         "sphinx>=2,<4",
         "linkify-it-py~=1.0.1",
         "myst-nb~=0.11.1",
-        "jupytext>=1.8,<1.10",
+        "jupytext>=1.8,<1.11",
         "click",
         "setuptools",
         "nbformat",

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         "sphinx>=2,<4",
         "linkify-it-py~=1.0.1",
         "myst-nb~=0.11.1",
-        "jupytext~=1.8.0",
+        "jupytext>=1.8,<1.10",
         "click",
         "setuptools",
         "nbformat",


### PR DESCRIPTION
Hi folks! I'm looking some more into the challenges of the [conda-forge PR](https://github.com/conda-forge/staged-recipes/pull/12516 )... trying another with the latest version, which lead to some more investigation.

It looks like the version pin on jupytext, which seems to move pretty fast, is starting to make it harder to get an internally consistent environment. Sigh.

This expands the pin to include the 1.10.x line, which is the first one I could get that seemed to work. We'll see what CI has to say about the matter, but no doubt there are some other insights y'all can share.

Anyhow, after some light translation of the runtime deps of HEAD (e.g. `_` to `-`, the occasional `-python`, etc.) with a `mamba` solve (one does not simple _read_ the conda errors) I'm getting:

```
Problem: package myst-nb-0.11.1-pyhd8ed1ab_0 requires myst-parser ~=0.13.3, but none of the providers can be installed
```

The last version of `myst-nb` that would solve against `jupytext==1.8.*` is `0.11`, etc. etc. 

I guess another option altogether is making jupytext an `extra` dependency, but then `pip` won't help folks much down the line on their next solve.

More broadly: I know conda **isn't this project's problem**, but otherwise everything in the full test/docs stack except:

- [x] [`sphinxext-rediraffe`](https://github.com/wpilibsuite/sphinxext-rediraffe/pull/44)
- [ ] [`sphinx-book-theme 0.0.39`](https://github.com/conda-forge/sphinx-book-theme-feedstock/pull/5)

... is available on conda-forge, and works together (at least, tests pass locally), and once everything _does_ work, with tests and coverage, it will be a lot easier to maintain this beast when/if it lands.

Cheers!