### PR TITLE
🐛 FIX: Suppressing [myst.domains] warning for pdf builds

### DIFF
--- a/jupyter_book/config.py
+++ b/jupyter_book/config.py
@@ -42,6 +42,7 @@ def get_default_sphinx_config():
         html_sourcelink_suffix="",
         numfig=True,
         panels_add_bootstrap_css=False,
+        suppress_warnings=["myst.domains"],
     )
 
 

--- a/tests/test_config/test_config_sphinx_command.txt
+++ b/tests/test_config/test_config_sphinx_command.txt
@@ -25,3 +25,4 @@ nb_output_stderr = 'show'
 numfig = True
 panels_add_bootstrap_css = False
 pygments_style = 'sphinx'
+suppress_warnings = ['myst.domains']

--- a/tests/test_config/test_get_final_config_custom_myst_extensions.yml
+++ b/tests/test_config/test_get_final_config_custom_myst_extensions.yml
@@ -69,6 +69,8 @@ final:
   numfig: true
   panels_add_bootstrap_css: false
   pygments_style: sphinx
+  suppress_warnings:
+  - myst.domains
 metadata:
   latex_doc_overrides:
     title: My Jupyter Book

--- a/tests/test_config/test_get_final_config_empty_.yml
+++ b/tests/test_config/test_get_final_config_empty_.yml
@@ -66,6 +66,8 @@ final:
   numfig: true
   panels_add_bootstrap_css: false
   pygments_style: sphinx
+  suppress_warnings:
+  - myst.domains
 metadata:
   latex_doc_overrides:
     title: My Jupyter Book

--- a/tests/test_config/test_get_final_config_exclude_patterns_.yml
+++ b/tests/test_config/test_get_final_config_exclude_patterns_.yml
@@ -69,6 +69,8 @@ final:
   numfig: true
   panels_add_bootstrap_css: false
   pygments_style: sphinx
+  suppress_warnings:
+  - myst.domains
 metadata:
   latex_doc_overrides:
     title: My Jupyter Book

--- a/tests/test_config/test_get_final_config_execute_method_.yml
+++ b/tests/test_config/test_get_final_config_execute_method_.yml
@@ -68,6 +68,8 @@ final:
   numfig: true
   panels_add_bootstrap_css: false
   pygments_style: sphinx
+  suppress_warnings:
+  - myst.domains
 metadata:
   latex_doc_overrides:
     title: My Jupyter Book

--- a/tests/test_config/test_get_final_config_extended_syntax_.yml
+++ b/tests/test_config/test_get_final_config_extended_syntax_.yml
@@ -66,6 +66,8 @@ final:
   numfig: true
   panels_add_bootstrap_css: false
   pygments_style: sphinx
+  suppress_warnings:
+  - myst.domains
 metadata:
   latex_doc_overrides:
     title: My Jupyter Book

--- a/tests/test_config/test_get_final_config_html_extra_footer_.yml
+++ b/tests/test_config/test_get_final_config_html_extra_footer_.yml
@@ -68,6 +68,8 @@ final:
   numfig: true
   panels_add_bootstrap_css: false
   pygments_style: sphinx
+  suppress_warnings:
+  - myst.domains
 metadata:
   latex_doc_overrides:
     title: My Jupyter Book

--- a/tests/test_config/test_get_final_config_latex_doc_.yml
+++ b/tests/test_config/test_get_final_config_latex_doc_.yml
@@ -70,6 +70,8 @@ final:
   numfig: true
   panels_add_bootstrap_css: false
   pygments_style: sphinx
+  suppress_warnings:
+  - myst.domains
 metadata:
   latex_doc_overrides:
     targetname: book.tex

--- a/tests/test_config/test_get_final_config_launch_buttons_.yml
+++ b/tests/test_config/test_get_final_config_launch_buttons_.yml
@@ -68,6 +68,8 @@ final:
   numfig: true
   panels_add_bootstrap_css: false
   pygments_style: sphinx
+  suppress_warnings:
+  - myst.domains
 metadata:
   latex_doc_overrides:
     title: My Jupyter Book

--- a/tests/test_config/test_get_final_config_repository_.yml
+++ b/tests/test_config/test_get_final_config_repository_.yml
@@ -68,6 +68,8 @@ final:
   numfig: true
   panels_add_bootstrap_css: false
   pygments_style: sphinx
+  suppress_warnings:
+  - myst.domains
 metadata:
   latex_doc_overrides:
     title: My Jupyter Book

--- a/tests/test_config/test_get_final_config_sphinx_.yml
+++ b/tests/test_config/test_get_final_config_sphinx_.yml
@@ -65,6 +65,8 @@ final:
   numfig: true
   panels_add_bootstrap_css: false
   pygments_style: sphinx
+  suppress_warnings:
+  - myst.domains
 metadata:
   latex_doc_overrides:
     title: My Jupyter Book

--- a/tests/test_config/test_get_final_config_title_.yml
+++ b/tests/test_config/test_get_final_config_title_.yml
@@ -67,6 +67,8 @@ final:
   numfig: true
   panels_add_bootstrap_css: false
   pygments_style: sphinx
+  suppress_warnings:
+  - myst.domains
 metadata:
   latex_doc_overrides:
     title: hallo


### PR DESCRIPTION
This PR suppresses the following warning:

`WARNING: Domain 'sphinxcontrib.bibtex.domain::cite' has not implemented a `resolve_any_xref` method [myst.domains]`

The fix will be present in the next release of sphincontrib.bibtex, after which we will undo this change.

Mentioned in the following issue:

https://github.com/executablebooks/jupyter-book/issues/1228