### PR TITLE
TST: Run tests daily to check software stack

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,8 @@ on:
     tags:
       - 'v*'
   pull_request:
+  schedule:
+    - cron:  '0 0 * * *'
 
 jobs:
 


### PR DESCRIPTION
This PR runs the `test.yml` through github actions on a daily basis to check for regressions introduced by the software stack. 

@chrisjsewell I am not aware of any `version` bots that could assist with this. The [renovate](https://github.com/renovatebot/renovate) app looks interesting but I haven't used it. I would be interested if anyone else has. 