### PR TITLE
⬆️ UPGRADE:  myst-nb v0.12.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "docutils>=0.15",
         "sphinx>=2,<4",
         "linkify-it-py~=1.0.1",
-        "myst-nb~=0.11.1",
+        "myst-nb~=0.12.0",
         "jupytext~=1.8.0",
         "click",
         "setuptools",


### PR DESCRIPTION
This PR upgrades `myst-nb` to `v0.12.0`

https://github.com/executablebooks/MyST-NB/blob/master/CHANGELOG.md#0120---2021-02-23