### PR TITLE
🚀 RELEASE: Version 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## v0.10.1 2021-02-24
+
+[full changelog](https://github.com/executablebooks/jupyter-book/compare/v0.10.0...4c2210b6a74067bfe37afef8197b86f198eeaa52) | [GitHub contributors page for this release](https://github.com/executablebooks/jupyter-book/graphs/contributors?from=2021-01-30&to=2021-01-24&type=c)
+
+This is a minor update to include recent improvements made [MyST-NB](https://github.com/executablebooks/myst-nb)
+
+## New
+
+
+
 ## v0.10.0 2021-02-01
 
 [full changelog](https://github.com/executablebooks/jupyter-book/compare/v0.9.1...d3c78097edda4fefb672e32344c3806c9cdc7a72) | [GitHub contributors page for this release](https://github.com/executablebooks/jupyter-book/graphs/contributors?from=2020-12-22&to=2021-01-30&type=c)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This is a minor update to include recent improvements made to [MyST-NB](https://
 
 * ⬆ UPGRADE: myst-nb v0.12.0 ([#1086](https://github.com/executablebooks/jupyter-book/pull/1086), [@choldgraf](https://github.com/choldgraf))
 
+### Maintain
+
+* 🔧 MAINTAIN: Expand `jupytext` version pinning ([#1221](https://github.com/executablebooks/jupyter-book/pull/1221), [@bollwyvl](https://github.com/bollwyvl))
 
 ## v0.10.0 2021-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Change Log
 
-## v0.10.1 2021-02-24
+## v0.10.1 2021-03-02
 
-[full changelog](https://github.com/executablebooks/jupyter-book/compare/v0.10.0...4c2210b6a74067bfe37afef8197b86f198eeaa52) | [GitHub contributors page for this release](https://github.com/executablebooks/jupyter-book/graphs/contributors?from=2021-01-30&to=2021-01-24&type=c)
+[full changelog](https://github.com/executablebooks/jupyter-book/compare/v0.10.0...a73538c22d6c8c7b7b198db79ada0f801d685856) | [GitHub contributors page for this release](https://github.com/executablebooks/jupyter-book/graphs/contributors?from=2021-01-30&to=2021-03-02&type=c)
 
-This is a minor update to include recent improvements made [MyST-NB](https://github.com/executablebooks/myst-nb)
+This is a minor update to include recent improvements made to [MyST-NB](https://github.com/executablebooks/myst-nb)
 
-## New
+### New
 
+1. An **experimental** MyST-NB feature that enables loading of code from a file for `code-cell` directives using a `:load: <file>` option. Additional information is available in the [myst-nb documentation](https://myst-nb.readthedocs.io/en/latest/use/markdown.html#syntax-for-code-cells)
+
+### Upgrades
+
+* ⬆ UPGRADE: myst-nb v0.12.0 ([#1086](https://github.com/executablebooks/jupyter-book/pull/1086), [@choldgraf](https://github.com/choldgraf))
 
 
 ## v0.10.0 2021-02-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is a minor update to include recent improvements made to [MyST-NB](https://
 
 ### Upgrades
 
-* ⬆ UPGRADE: myst-nb v0.12.0 ([#1086](https://github.com/executablebooks/jupyter-book/pull/1086), [@choldgraf](https://github.com/choldgraf))
+* ⬆ UPGRADE: myst-nb v0.12.0 ([#1238](https://github.com/executablebooks/jupyter-book/pull/1238), [@mmcky](https://github.com/mmcky))
 
 ### Maintain
 

--- a/jupyter_book/__init__.py
+++ b/jupyter_book/__init__.py
@@ -5,7 +5,7 @@ from .toc import add_toc_to_sphinx, add_toctree
 from .directive.toc import TableofContents, SwapTableOfContents
 
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 
 
 def add_static_files(app, config):


### PR DESCRIPTION
This PR is a minor release that updates `jupyter-book` to version `0.10.1`

[full changelog](https://github.com/executablebooks/jupyter-book/compare/v0.10.0...a73538c22d6c8c7b7b198db79ada0f801d685856)
