### PR TITLE
Fixes https://github.com/executablebooks/jupyter-book/issues/1270

### DIFF
--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -256,6 +256,9 @@ def _find_content_structure(
     """Parse a folder and sub-folders for content and return a dict."""
     if skip_text is None:
         skip_text = []
+    elif not isinstance(skip_text, list):
+        skip_text = [skip_text]
+
     skip_text.append(".ipynb_checkpoints")
 
     path = Path(path)


### PR DESCRIPTION
Current toc generator function `_find_content_structure()` treats `skip_text` as a list when it may be a string.