### PR TITLE
FIX: Error generating contents using filenames containing `.`

### DIFF
--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -237,8 +237,7 @@ def _gen_toctree(options, subsections, parent_suff):
 
 def _content_path_to_yaml(path, root_path, split_char="_", add_titles=True):
     """Return a YAML entry for the TOC from a path."""
-    path = path.with_suffix("")
-    if path.name == "index":
+    if path.with_suffix("").name == "index":
         title = _filename_to_title(path.resolve().parent.name, split_char=split_char)
     else:
         title = _filename_to_title(path.name, split_char=split_char)


### PR DESCRIPTION
FIXES: https://github.com/executablebooks/jupyter-book/issues/1049

The `_filename_to_title()` function runs `path.with_suffix("")`.

The suffix is currently stripped in  `_content_path_to_yaml()` and then again in `_filename_to_title()`. If the filename contains a `.` the second call splits the filename at the point.

Correction is: don't strip suffix in   `_content_path_to_yaml(()` .