### PR TITLE
🔧 MAINT:  pin docutils around .16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "pyyaml",
-        "docutils>=0.15",
+        "docutils>=0.15,<0.17",
         "sphinx>=2,<4",
         "linkify-it-py~=1.0.1",
         "myst-nb~=0.12.0",


### PR DESCRIPTION
Pinning `docutils` to avoid this bug, also closes #1288 

Uses `<=` because using `~=` still results in 0.17 because a dependency installs it first.

Will push a changelog when I have a moment, going to release now if tests pass because this is a breaking bug.