### PR TITLE
Pin sphinx-thebe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         "sphinx-comments",
         "sphinxcontrib-bibtex~=2.2.0",
         "sphinx_book_theme>=0.0.39",
-        "sphinx-thebe>=0.0.6",
+        "sphinx-thebe>=0.0.6,<=0.0.8",
         "sphinx-panels~=0.5.2",
         "nested-lookup~=0.2.21",
         "jupyterbook-latex~=0.2.0",


### PR DESCRIPTION
There is a proposal for changing sphinx-thebe API in a backwards incompatible way: https://github.com/executablebooks/sphinx-thebe/issues/17. Implementing that proposal would break jupyter-book, and hence I propose to first pin sphinx-thebe here.