### PR TITLE
📚 DOCS: Reorganizing top-level documentation structure

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -11,10 +11,19 @@ parts:
     - file: start/publish
   - file: tutorials/references
   - file: basics/questions
-- caption: Create your book
+- caption: Topic Guides
   chapters:
-  - file: customize/toc
-  - file: basics/create
+  - file: basics/organize
+    sections:
+    - file: customize/toc
+    - file: basics/create
+    - file: file-types/index
+      sections:
+      - file: file-types/markdown
+      - file: file-types/notebooks
+      - file: file-types/myst-notebooks
+      - file: file-types/jupytext
+      - file: file-types/restructuredtext
   - file: content/index
     sections:
     - file: content/myst
@@ -25,42 +34,42 @@ parts:
     - file: content/math
     - file: content/figures
     - file: content/metadata
-    - file: interactive/hiding
-  - file: file-types/index
-    sections:
-    - file: file-types/markdown
-    - file: file-types/notebooks
-    - file: file-types/myst-notebooks
-    - file: file-types/jupytext
-    - file: file-types/restructuredtext
-- caption: Build your book
-  chapters:
-  - file: basics/build
+
   - file: execute/index
     sections:
     - file: content/code-outputs
     - file: content/execute
-  - file: interactive/interactive
-  - file: basics/page
-- caption: Publish your book
-  chapters:
+    - file: interactive/interactive
+
+  - file: basics/building/index
+    sections:
+    - file: basics/build
+    - file: basics/page
+    - file: advanced/pdf
+
   - file: publish/web
     sections:
     - file: publish/gh-pages
     - file: publish/netlify
-  - file: basics/repository
-  - file: interactive/launchbuttons
-  - file: interactive/comments
+
+  - file: web/index
     sections:
-    - file: interactive/comments/hypothesis
-    - file: interactive/comments/utterances
-  - file: advanced/html
-  - file: advanced/pdf
-- caption: Advanced usage
-  chapters:
-  - file: advanced/sphinx
-  - file: advanced/windows
-  - file: explain/sphinx
+    - file: basics/repository
+    - file: interactive/hiding
+    - file: interactive/launchbuttons
+    - file: interactive/thebe
+    - file: interactive/comments
+      sections:
+      - file: interactive/comments/hypothesis
+      - file: interactive/comments/utterances
+    - file: advanced/html
+
+  - file: advanced/index
+    sections:
+    - file: advanced/sphinx
+    - file: advanced/windows
+    - file: explain/sphinx
+
 - caption: Reference
   chapters:
   - file: customize/config

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -1,0 +1,3 @@
+# Advanced Jupyter Book Usage
+
+These sections cover a few ways to customize and configure Jupyter Book that require extra knowledge about the Sphinx ecosystem, more challenging workflows, etc.

--- a/docs/advanced/pdf.md
+++ b/docs/advanced/pdf.md
@@ -1,4 +1,4 @@
-# Publish PDFs of your book
+# Build a PDF
 
 It is possible to build a single PDF that contains all of your book's content. This
 page describes a couple ways to do so.

--- a/docs/basics/build.md
+++ b/docs/basics/build.md
@@ -1,4 +1,31 @@
-# Build your book
+# Build a book
+
+When you've written your book's content, it is now time to build outputs for your book so that you may share them with others.
+For example, you may wish to build HTML files to host as a static website, or a PDF to share with colleagues.
+
+## Build via the command-line
+
+The basic way to build your book is via the following command:
+
+```bash
+jupyter-book build <path-to-book>
+```
+
+In addition, you may control the kinds of outputs that are generated, and the ways in which your book conducts the build.
+The rest of the sections on this page cover some of these options.
+
+## Types of build outputs
+
+You can build a variety of outputs using Jupyter Book. To choose a different builder, use the `--builder <builder-name>` configuration when running `jupyter-book build` from the command-line. Here is a list of builders that are available to you:
+
+- `html`: HTML outputs (default)
+- `singlehtml`: A single HTML page for your book
+- `dirhtml`: HTML outputs with `<filename>/index.html` structure.
+- `pdfhtml`: Build a PDF via HTML outputs (see [](pdf:html))
+- `linkcheck`: Run the Sphinx link checker (see [](html:link-check))
+- `latex`: Build Latex files for your book
+- `pdflatex`: Build a PDF of your book via Latex (see [](pdf:latex))
+
 
 (clean-build)=
 ## Clean your book's generated files
@@ -51,16 +78,3 @@ but will still attempt to run the full build (`--keep-going`),
 so that you can see all errors in one run.
 
 You can also use `-v` or `-vvv` to increase verbosity.
-
-
-## A list of book output types
-
-You can build a variety of outputs using Jupyter Book. To choose a different builder, use the `--builder <builder-name>` configuration when running `jupyter-book build` from the command-line. Here is a list of builders that are available to you:
-
-- `html`: HTML outputs (default)
-- `singlehtml`: A single HTML page for your book
-- `dirhtml`: HTML outputs with `<filename>/index.html` structure.
-- `pdfhtml`: Build a PDF via HTML outputs (see [](pdf:html))
-- `linkcheck`: Run the Sphinx link checker (see [](html:link-check))
-- `latex`: Build Latex files for your book
-- `pdflatex`: Build a PDF of your book via Latex (see [](pdf:latex))

--- a/docs/basics/building/index.md
+++ b/docs/basics/building/index.md
@@ -1,0 +1,3 @@
+# Build your book outputs
+
+These sections cover aspects of **building your book** - that is, generating output artifacts using your book pages.

--- a/docs/basics/organize.md
+++ b/docs/basics/organize.md
@@ -1,0 +1,6 @@
+# Organize your book
+
+These sections describe how to organize the structure of your book.
+
+```{tableofcontents}
+```

--- a/docs/basics/page.md
+++ b/docs/basics/page.md
@@ -1,5 +1,5 @@
 (publish:page)=
-# Build a standalone page
+# Build a single page
 
 Sometimes you'd like to build a single page of content rather than an entire book.
 For example, if you'd like to generate a web-friendly HTML page from a Jupyter notebook for a report or publication.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,4 +1,4 @@
-# Book content and syntax
+# Write narrative content
 
 In this section we'll cover the many ways that you can write content for your book.
 You can write book content in a variety of markup languages and file formats, and create special kinds of content for your book with MyST Markdown.

--- a/docs/content/metadata.md
+++ b/docs/content/metadata.md
@@ -10,7 +10,7 @@ This is a short guide to how metadata is added to various kinds of content in Ju
 You can control the behaviour of Jupyter Book by putting custom tags
 in the metadata of your cells. This allows you to do things like
 {doc}`automatically hide code cells <../interactive/hiding>` as well as
-{ref}`add interactive widgets to cells <launch/thebelab>`.
+{ref}`add interactive widgets to cells <launch/thebe>`.
 
 ### Adding tags using notebook interfaces
 

--- a/docs/customize/config.md
+++ b/docs/customize/config.md
@@ -1,50 +1,10 @@
-# Configure book settings
+# Configuration reference
 
-In Jupyter Book, most configurations are controlled in a **YAML configuration file (`_config.yml`)**.
-This file controls a number of options that you may use to configure your book
-(the [defaults](config:defaults) can be found at the bottom of this page).
+You can configure Jupyter Book with a **YAML configuration file (`_config.yml`)**.
+This file controls a number of options and feature flags.
 
-This page describes the general structure of `_config.yml`
-and how you can use it to control some basic parts of your book.
-The rest of the pages in this section describe specific features in more detail.
-
-## Structure of `_config.yml`
-
-Here is a very simple `_config.yml` configuration (it is taken from
-{download}`the demo book config file <../../jupyter_book/book_template/_config.yml>`):
-
-```yaml
-# Book settings
-title: My sample book
-author: The Jupyter Book Community
-logo: 'images/logo.png'
-```
-
-As you can see, keys correspond to configuration options and their values are how you control the behaviour of the book.
-In this case:
-
-* **title**: sets the title of your book.
-  In the HTML output, it is displayed in the left sidebar.
-* **author**: sets the book's author.
-  In the HTML output, it is displayed in the footer.
-* **logo**: sets the logo of the book, relative to the book root.
-  In the HTML output, it is displayed above the title in the left sidebar.
-
-There are also some configuration options that are nested.
-For example, to configure your book to include **Binder links** in any section built from a Jupyter notebook,
-you may use the following configuration:
-
-```yaml
-# Information about where the book exists on the web
-repository:
-  url                       : https://github.com/yourusername/yourbookrepo
-
-# Configure your Binder links, such as the URL of the BinderHub.
-launch_buttons:
-  binderhub_url             : https://mybinder.org
-```
-
-Look out for different book configuration options throughout this book's documentation.
+This page is a reference for the `_config.yml` structure along with default values for each option.
+For information about using and configuring specific features, see the **Topic Guides**.
 
 :::{caution}
 YAML can be tricky when it comes to how it treats certain kinds of values. For example,
@@ -54,33 +14,6 @@ strings around them. For example, `false`, `true`, `off`, etc. In addition, pure
 numbers will be converted to `float` or `int` unless you put strings around them.
 :::
 
-
-
-### Specifying Sphinx Configuration Values
-
-To set additional Sphinx configurations:
-
-```yaml
-sphinx:
-  config:
-    my_option: my_value
-```
-
-:::{warning}
-Any options set in this section will **override** default configurations set by Jupyter Book.
-Use at your own risk!
-:::
-
-If you wish to inspect a `conf.py` representation of the generated configuration,
-which Jupyter Book will pass to Sphinx, from the command line run:
-
-```bash
-jb config sphinx mybookname/
-```
-
-:::{seealso}
-The advanced section on [Sphinx configuration](advanced/sphinx-config).
-:::
 
 (config:defaults)=
 ## Configuration defaults

--- a/docs/customize/toc.md
+++ b/docs/customize/toc.md
@@ -1,18 +1,22 @@
-# Structure your book with the Table of Contents
+# Structure your book's pages
 
-There are many ways in which you can control the table of contents for
-your book. Most of them involve adding syntax to your `_toc.yml` file.
-
-This page covers a few common options.
+Your book's structure is determined by a **Table of Contents**.
+This is a YAML file (called `_toc.yml`) that defines a structure that Jupyter Book uses to create the order and nesting of pages.
 
 ```{note}
 The {download}`_toc.yml file for this site <../_toc.yml>` has an entry for each
 of the features described below for reference.
 ```
 
-## General TOC structure
+## Table of Contents structure
 
 The table of contents is broadly organized like so:
+
+```yaml
+format: jb-book  # Tells Jupyter Book what kind of structure to expect
+root: index  # A path to the *root page* (landing page) of your book
+
+```
 
 * The first entry of your `_toc.yml` file is the *introduction* to your book.
   It is the landing page for the HTML of your book.

--- a/docs/execute/index.md
+++ b/docs/execute/index.md
@@ -1,4 +1,4 @@
-# Execute your computational content
+# Write executable content
 
 This section covers topics related to **executing** your content and interweaving **computational material** with your narrative. For example, if you're writing your content as _Jupyter Notebooks_ and wish for the output of cells to be included with your book.
 

--- a/docs/interactive/launchbuttons.ipynb
+++ b/docs/interactive/launchbuttons.ipynb
@@ -4,13 +4,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Connect with interactive environments\n",
+    "# Launch into interactive computing interfaces\n",
     "\n",
-    "Because Jupyter Books are built with Jupyter notebooks, you can allow users to launch\n",
-    "live Jupyter sessions in the cloud directly from your book. This lets readers quickly interact with your content in a traditional coding interface.\n",
-    "There now exist numerous online notebook services - a good comparison is provided [in this article](https://www.dataschool.io/cloud-services-for-jupyter-notebook) - and the following sections describes the available integrations provided by Jupyter Book.\n",
+    "Because Jupyter Books are built with Jupyter notebooks, you can allow users to launch live Jupyter sessions in the cloud directly from your book.\n",
+    "This lets readers quickly interact with your content in a traditional coding interface.\n",
+    "They do so by clicking a **Launch Button** that takes them to an interactive environment.\n",
     "\n",
-    "In each case, you'll need to tell Jupyter Book where your book content lives online.\n",
+    "There are numerous online notebook services - a good comparison is provided [in this article](https://www.dataschool.io/cloud-services-for-jupyter-notebook) - and the following sections describes the available integrations provided by Jupyter Book.\n",
+    "\n",
+    "(launchbuttons/configuration)=\n",
+    "## Common launch button configuration\n",
+    "\n",
+    "In the case of each interactive service, you'll need to tell Jupyter Book where your book content lives online.\n",
     "To do so, use this configuration in `_config.yml`:\n",
     "\n",
     "```yaml\n",
@@ -61,6 +66,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "(launchbuttons/binder)=\n",
     "## Add a Launch on {term}`Binder` button\n",
     "\n",
     "{term}`BinderHub` can be used to build the environment needed to run a repository, and provides\n",
@@ -134,104 +140,6 @@
     "```{note}\n",
     "Google Colab links will only work for pages that have the `.ipynb` extension.\n",
     "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "(launch/thebelab)=\n",
-    "## Live interactive pages with Thebe\n",
-    "\n",
-    "This section describes how to bring interactivity to your book. This lets users\n",
-    "run code and see outputs *without leaving the page*. Interactivity is provided\n",
-    "by a kernel running on the public [**MyBinder**](https://mybinder.org) service.\n",
-    "\n",
-    "```{warning}\n",
-    "This is an experimental feature, and may change in the future or work unexpectedly.\n",
-    "```\n",
-    "\n",
-    "To make your content interactive without requiring readers to leave the current page,\n",
-    "you can use a project called [Thebe](https://github.com/executablebooks/thebe). \n",
-    "This provides you with a {kbd}`Live Code` button that, when clicked, will convert each code cell into\n",
-    "an **interactive** cell that can be edited. It also adds a \"run\" button to each cell,\n",
-    "and connects to a Binder kernel running in the cloud.\n",
-    "\n",
-    "To add a Thebe button to your Jupyter Book pages, use the following configuration:\n",
-    "\n",
-    "```yaml\n",
-    "launch_buttons:\n",
-    "  thebe                  : true\n",
-    "```\n",
-    "\n",
-    "In addition, you can configure the Binder settings that are used to provide a kernel for\n",
-    "Thebe to run the code. These use the same configuration fields as the BinderHub interact\n",
-    "buttons described above.\n",
-    "\n",
-    "For an example, click the **Thebe** button above on this page, and run the code below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "plt.ion()\n",
-    "\n",
-    "x = np.arange(500)\n",
-    "y = np.random.randn(500)\n",
-    "\n",
-    "fig, ax = plt.subplots()\n",
-    "ax.scatter(x, y, c=y, s=x)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Running cells in Thebe when it is initialized\n",
-    "\n",
-    "Sometimes you'd like to initialize the kernel that Thebe uses by running\n",
-    "some code ahead of time. This might be code that you then hide from the user\n",
-    "in order to narrow the focus of what they interact with. This is possible\n",
-    "by using Jupyter Notebook tags.\n",
-    "\n",
-    "Adding the tag `thebe-init` to any code cell will cause Thebe to\n",
-    "run this cell after it has received a kernel. Any subsequent Thebe cells\n",
-    "will have access to the same environment (e.g. any module imports made in the\n",
-    "initialization cell).\n",
-    "\n",
-    "You can then pair this with something like `hide-input` in order to run\n",
-    "initialization code that your user doesn't immediately see. For example,\n",
-    "below we'll initialize a variable in a hidden cell, and then tell another\n",
-    "cell to print the output of that variable."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-input",
-     "thebe-init"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "my_hidden_variable = 'wow, it worked!'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# The variable for this is defined in the cell above!\n",
-    "print(my_hidden_variable)"
    ]
   }
  ],

--- a/docs/interactive/thebe.md
+++ b/docs/interactive/thebe.md
@@ -1,0 +1,85 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.10.3
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+(launch/thebe)=
+# Make your code cells executable
+
+This section describes how to bring interactivity to your book. This lets users
+run code and see outputs *without leaving the page*. Interactivity is provided
+by a kernel running on the public [**MyBinder**](https://mybinder.org) service.
+
+For an example, click the {fa}`rocket` --> {guilabel}`Live Code` button above on this page, and run the code below.
+
+```{code-cell} ipython3
+import numpy as np
+import matplotlib.pyplot as plt
+plt.ion()
+
+x = np.arange(500)
+y = np.random.randn(500)
+
+fig, ax = plt.subplots()
+ax.scatter(x, y, c=y, s=x)
+```
+
+:::{warning}
+This is an experimental feature, and may change in the future or work unexpectedly.
+:::
+
+## Activate Thebe
+
+To make your content interactive without requiring readers to leave the current page, you can use a project called [Thebe](https://github.com/executablebooks/thebe).
+This provides you with a {guilabel}`Live Code` button that, when clicked, will convert each code cell into an **interactive** cell that can be edited.
+It also adds a "run" button to each cell, and connects to a Binder kernel running in the cloud.
+
+To add a Thebe button to your Jupyter Book pages, take these steps:
+
+1. First, [add the common launch button configuration](launchbuttons/configuration). This makes it possible for `thebe/` to use the correct environment and file paths for your content.
+2. Activate Thebe integration with the following configuration:
+
+   ```yaml
+   launch_buttons:
+     thebe                  : true
+   ```
+
+## Configure Thebe
+
+In addition, you can configure the Binder settings that are used to provide a kernel for Thebe to run the code.
+These use the same configuration fields as the BinderHub interact buttons described above.
+For information about how to do this, see [the BinderHub launch button documentation](launchbuttons/binder).
+
++++
+
+## Pre-execute cells when Thebe is initialized
+
+Sometimes you'd like to run some code cells *immediately* when a kernel is requested.
+This might be code that you then hide from the user in order to narrow the focus of what they interact with.
+This is possible by using **cell tags** for the Jupyter Notebook.
+
+Adding the tag {guilabel}`thebe-init` to any code cell will cause Thebe to run this cell after it has received a kernel.
+Any subsequent Thebe cells will have access to the same environment (e.g. any module imports made in the initialization cell).
+
+You can then pair this with something like {guilabel}`hide-input` in order to run initialization code that your user doesn't immediately see.
+For example, below we'll initialize a variable in a hidden cell, and then tell another cell to print the output of that variable.
+
+```{code-cell} ipython3
+:tags: [hide-input, thebe-init]
+
+my_hidden_variable = 'wow, it worked!'
+```
+
+```{code-cell} ipython3
+# The variable for this is defined in the cell above!
+print(my_hidden_variable)
+```

--- a/docs/reference/cheatsheet.md
+++ b/docs/reference/cheatsheet.md
@@ -11,7 +11,7 @@ kernelspec:
 ---
 
 (myst_cheatsheet)=
-# MyST cheat sheet
+# MyST syntax cheat sheet
 
 ## Headers
 

--- a/docs/web/index.md
+++ b/docs/web/index.md
@@ -1,0 +1,3 @@
+# Web-based features
+
+These sections cover features that are designed for **web outputs**.


### PR DESCRIPTION
This is a continuation of #1283 to update the top level content for our docs and make them easier to browse. It nests a few things under the top header, since it's now easier for people to quickly browse those levels due to the dropdown arrow.