### PR TITLE
🔧 MAINT: Explain jupytext dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     docutils>=0.15,<0.17
     jsonschema
     jupyterbook-latex~=0.3.1
+    # Include Jupytext to ensure users have the right version, even if not strictly necessary
     jupytext>=1.8,<1.11
     linkify-it-py~=1.0.1
     myst-nb~=0.12.0


### PR DESCRIPTION
This removes the `jupytext` dependency, because we don't use it anywhere except for in the `utils.py` module, and even there we use a try/except block to check for its install status. It looks like it was added to setup.py by myself here:

https://github.com/executablebooks/jupyter-book/commit/0ffed2688a0ee8dcefb7aeddf317b927c94981fe#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R71

but I don't think this was strictly necessary