### PR TITLE
⬆ UPDATE: sphinx-external-toc v0.2.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     sphinx>=2,<4
     sphinx-comments
     sphinx-copybutton
-    sphinx-external-toc~=0.1.0
+    sphinx-external-toc~=0.2.1
     sphinx-jupyterbook-latex~=0.4.0
     sphinx-panels~=0.5.2
     sphinx-thebe~=0.0.8


### PR DESCRIPTION
This reverts a change in https://github.com/executablebooks/jupyter-book/pull/1340 that I believe was unintentional.