### PR TITLE
🔧 MAINTAIN: Remove uneeded dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,8 +42,6 @@ install_requires =
     jupytext>=1.8,<1.11
     linkify-it-py~=1.0.1
     myst-nb~=0.12.0
-    nbconvert<6
-    nbformat
     pyyaml
     sphinx>=2,<4
     sphinx-comments


### PR DESCRIPTION
Neither nbconvert or nbformat are direct dependencies of jupyter-book

closes #1371 