### PR TITLE
✨IMPROVE: Enable singlehtml as a builder option from the cli

### DIFF
--- a/docs/basics/build.md
+++ b/docs/basics/build.md
@@ -16,7 +16,7 @@ The rest of the sections on this page cover some of these options.
 
 ## Types of build outputs
 
-You can build a variety of outputs using Jupyter Book. To choose a different builder, use the `--builder <builder-name>` configuration when running `jupyter-book build` from the command-line. 
+You can build a variety of outputs using Jupyter Book. To choose a different builder, use the `--builder <builder-name>` configuration when running `jupyter-book build` from the command-line.
 
 Here is a list of builders that are available to you:
 

--- a/docs/basics/build.md
+++ b/docs/basics/build.md
@@ -16,7 +16,9 @@ The rest of the sections on this page cover some of these options.
 
 ## Types of build outputs
 
-You can build a variety of outputs using Jupyter Book. To choose a different builder, use the `--builder <builder-name>` configuration when running `jupyter-book build` from the command-line. Here is a list of builders that are available to you:
+You can build a variety of outputs using Jupyter Book. To choose a different builder, use the `--builder <builder-name>` configuration when running `jupyter-book build` from the command-line. 
+
+Here is a list of builders that are available to you:
 
 - `html`: HTML outputs (default)
 - `singlehtml`: A single HTML page for your book

--- a/jupyter_book/cli/main.py
+++ b/jupyter_book/cli/main.py
@@ -69,6 +69,7 @@ def main():
 BUILDER_OPTS = {
     "html": "html",
     "dirhtml": "dirhtml",
+    "singlehtml": "singlehtml",
     "pdfhtml": "singlehtml",
     "latex": "latex",
     "pdflatex": "latex",

--- a/jupyter_book/cli/main.py
+++ b/jupyter_book/cli/main.py
@@ -272,6 +272,8 @@ def build(
         OUTPUT_PATH = BUILD_PATH.joinpath("latex")
     elif builder in ["dirhtml"]:
         OUTPUT_PATH = BUILD_PATH.joinpath("dirhtml")
+    elif builder in ["singlehtml"]:
+        OUTPUT_PATH = BUILD_PATH.joinpath("singlehtml")
     elif builder in ["custom"]:
         OUTPUT_PATH = BUILD_PATH.joinpath(custom_builder)
         BUILDER_OPTS["custom"] = custom_builder

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -63,6 +63,7 @@ def test_build_dirhtml_from_template(temp_with_override, cli):
     assert html.joinpath("index.html").exists()
     assert html.joinpath("intro", "index.html").exists()
 
+
 def test_build_singlehtml_from_template(temp_with_override, cli):
     """Test building the book template with singlehtml."""
     # Create the book from the template
@@ -75,6 +76,7 @@ def test_build_singlehtml_from_template(temp_with_override, cli):
     html = book.joinpath("_build", "singlehtml")
     assert html.joinpath("index.html").exists()
     assert html.joinpath("intro.html").exists()
+
 
 def test_custom_config(cli, build_resources):
     """Test a variety of custom configuration values."""

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -63,6 +63,18 @@ def test_build_dirhtml_from_template(temp_with_override, cli):
     assert html.joinpath("index.html").exists()
     assert html.joinpath("intro", "index.html").exists()
 
+def test_build_singlehtml_from_template(temp_with_override, cli):
+    """Test building the book template with singlehtml."""
+    # Create the book from the template
+    book = temp_with_override / "new_book"
+    _ = cli.invoke(commands.create, book.as_posix())
+    build_result = cli.invoke(
+        commands.build, [book.as_posix(), "-n", "-W", "--builder", "singlehtml"]
+    )
+    assert build_result.exit_code == 0, build_result.output
+    html = book.joinpath("_build", "singlehtml")
+    assert html.joinpath("index.html").exists()
+    assert html.joinpath("intro.html").exists()
 
 def test_custom_config(cli, build_resources):
     """Test a variety of custom configuration values."""


### PR DESCRIPTION
This PR enables access to the `singlehtml` builder via `jupyter-book` cli

```
jb build <project> --builder=singlehtml
```

- [x] update docs
- [x] update tests

fixes #1399 