### PR TITLE
🚀 RELEASE: Updates in preparation for v0.11.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## v0.11.3
+
+This release enables the use of the [singlehtml builder](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.singlehtml.SingleFileHTMLBuilder) and updates [sphinx-thebe](https://github.com/executablebooks/sphinx-thebe) and [sphinx-book-theme](https://github.com/executablebooks/sphinx-book-theme)
+
+### New
+
+1. [builders] Add access to the [singlehtml](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.singlehtml.SingleFileHTMLBuilder) builder via the CLI [[PR #1418](https://github.com/executablebooks/jupyter-book/pull/1418)]
+
+### Upgrade
+
+1. [sphinx-thebe](https://sphinx-thebe.readthedocs.io/en/latest/changelog.html#v0-0-10-2021-08-24) is now version `0.0.10`
+2. [sphinx-book-theme](https://github.com/executablebooks/sphinx-book-theme/blob/master/CHANGELOG.md#v012---2021-08-25) is now version `0.1.3`
+
+
 ## v0.11.2
 
 This release introduces [sphinx-multitoc-numbering](https://github.com/executablebooks/sphinx-multitoc-numbering) for consistent numbering across a `part/chapter` book structure. It also includes improvements to `pdflatex` output, updates to the documentation and various maintenance tasks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This release enables the use of the [singlehtml builder](https://www.sphinx-doc.
 ### Upgrade
 
 1. [sphinx-thebe](https://sphinx-thebe.readthedocs.io/en/latest/changelog.html#v0-0-10-2021-08-24) is now version `0.0.10`
-2. [sphinx-book-theme](https://github.com/executablebooks/sphinx-book-theme/blob/master/CHANGELOG.md#v012---2021-08-25) is now version `0.1.3`
+2. [sphinx-book-theme](https://github.com/executablebooks/sphinx-book-theme/blob/master/CHANGELOG.md#v013---2021-08-25) is now version `0.1.3`
 
 
 ## v0.11.2

--- a/jupyter_book/__init__.py
+++ b/jupyter_book/__init__.py
@@ -1,7 +1,7 @@
 """Build a book with Jupyter Notebooks and Sphinx."""
 from pathlib import Path
 
-__version__ = "0.11.2"
+__version__ = "0.11.3"
 
 
 def add_static_files(app, config):


### PR DESCRIPTION
This PR sets up `jupyter-book` for a minor release of `v0.11.3`

@choldgraf I will wait until I clarify re: `sphinx-book-theme==0.1.3` and the CHANGELOG etc.

