### PR TITLE
pipenv cannot resolve dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     docutils>=0.15,<0.17
     jsonschema
     # Include Jupytext to ensure users have the right version, even if not strictly necessary
-    jupytext>=1.8,<1.11
+    # this causes a unsolvable dependency situation, as it is a indirect dependency it is dorpped here.... jupytext>=1.8,<1.11
     linkify-it-py~=1.0.1
     myst-nb~=0.12.0
     pyyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     # Include Jupytext to ensure users have the right version, even if not strictly necessary
     # this causes a unsolvable dependency situation, as it is a indirect dependency it is dorpped here.... jupytext>=1.8,<1.11
     linkify-it-py~=1.0.1
-    myst-nb~=0.12.0
+    myst-nb>=0.12.0
     pyyaml
     sphinx>=2,<4
     sphinx-comments


### PR DESCRIPTION
Hello,

First of all: I am using jupyter-book and jupyter lab for a while now and I am very happy with it!

While updating to a new version i encountered issues with unresolveable dependencies. 

pipenv install jupyter-book jupyterlab

was unable to find a set of packages (versions) which could fullfill all the requirements. 

I introduced these 2 changes to setup.cfg in order to breakt the impossible requirments, and am using the resulting install for a view hours now happily.

To depend on jupytext was disputed to begin with, relaxing the versions of myst-nb was necessary to fulfill requirements around myst-parser and markdown-it-py.

It was necessary for me to install a pre release version to achieve that...

# Resolution

This problem is not something that Jupyter Book has control over. Instead, it is an issue with `pipenv` itself (since it does not have a proper dependency resolver. See https://github.com/jazzband/pip-tools/issues/1372 for some discussion of this. However, the next chain of releases in the stack will make this problem go away in the short term. In addition, see https://github.com/executablebooks/MyST-NB/issues/355#issuecomment-907656056 for a workaround that uses `pip`s resolver.
