### PR TITLE
Add documentation on how to use custom-builder to generate epub

### DIFF
--- a/jupyter_book/cli/main.py
+++ b/jupyter_book/cli/main.py
@@ -120,9 +120,9 @@ BUILDER_OPTS = {
 @click.option(
     "--custom-builder",
     default=None,
-    help="Specify alternative builder name which allows jupyter-book to use a builder"
-    "provided by an external extension. This can only be used when using"
-    "--builder=custom",
+    help="Specify alternative builder provided by Sphinx, including text and epub. "
+    "This can only be used when using --builder=custom. Valid options listed at "
+    "https://www.sphinx-doc.org/en/master/man/sphinx-build.html",
 )
 @click.option(
     "-v", "--verbose", count=True, help="increase verbosity (can be repeated)"

--- a/jupyter_book/cli/main.py
+++ b/jupyter_book/cli/main.py
@@ -121,7 +121,7 @@ BUILDER_OPTS = {
     "--custom-builder",
     default=None,
     help="Specify alternative builder provided by Sphinx, including text and epub. "
-    "This can only be used when using --builder=custom. Valid options listed at "
+    "This can only be used with --builder=custom. Valid options listed at "
     "https://www.sphinx-doc.org/en/master/man/sphinx-build.html",
 )
 @click.option(


### PR DESCRIPTION
It's not immediately obvious that `custom-builder` can be used to generate epub, so changed the docstring to reflect that. 

Can confirm epub export works out of the box. Epub in calibre:

![image](https://user-images.githubusercontent.com/3516539/132099470-cdc100e7-491b-43b0-ac92-ab5ecc9b99e1.png)

Partially resolves https://github.com/executablebooks/jupyter-book/issues/229