### PR TITLE
DOCS: Update example of referencing equation

### DIFF
--- a/docs/content/references.md
+++ b/docs/content/references.md
@@ -155,6 +155,8 @@ w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
 ```
 ````
 ---
+rendered
+^^^
 ```{math}
 :label: my-math-ref
 w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}

--- a/docs/content/references.md
+++ b/docs/content/references.md
@@ -145,17 +145,28 @@ To reference other files of book content, use the `{doc}` role, or link directly
 
 To reference equations, first insert an equation with a label like so:
 
+`````{panels}
+source
+^^^
+````md
 ```{math}
 :label: my-math-ref
 w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
 ```
+````
+---
+```{math}
+:label: my-math-ref
+w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
+```
+`````
 
 To reference equations, use the `{eq}` role. It will automatically insert the number of the equation.
 Note that you cannot modify the text of equation links.
 
 For example:
 
-- `` See Equation `{eq}`my-math-ref` `` results in: See Equation {eq}`my-math-ref`
+- `` See Equation {eq}`my-math-ref` `` results in: See Equation {eq}`my-math-ref`
 - `` See Equation [](my-math-ref) `` results in: See Equation [](my-math-ref).
 
 


### PR DESCRIPTION
1) Most importantly, remove the **incorrect** extra tic mark in the first equation reference example.
2) Use a panel to show adding the label in the source instead of just showing the output
   because how the label could be inserted was confusing without an example (although I
   now see the other support ways.)

Dream wish list: Be able to use normal LaTeX \label{} in \begin{equation}, etc. ....