### PR TITLE
Fix typo in IPywidgets documentation

### DIFF
--- a/docs/interactive/interactive.ipynb
+++ b/docs/interactive/interactive.ipynb
@@ -146,7 +146,7 @@
     "## ipywidgets\n",
     "\n",
     "You may also run code for Jupyter Widgets in your document, and the interactive HTML\n",
-    "outputs will embed themselves in your side. See [the ipywidgets documentation](https://ipywidgets.readthedocs.io/en/latest/user_install.html)\n",
+    "outputs will embed themselves in your site. See [the ipywidgets documentation](https://ipywidgets.readthedocs.io/en/latest/user_install.html)\n",
     "for how to get set up in your own environment.\n",
     "\n",
     "```{admonition} Widgets often need a kernel\n",


### PR DESCRIPTION
Change `side`->`site`. One hopes that the widgets do not cause physical pain, although the visualizations may get under your skin 😄 