### PR TITLE
MAINT: Migrate test from sphinx-jupyterbook-latex

### DIFF
--- a/tests/books/sphinx-jupyterbook-latex/_config.yml
+++ b/tests/books/sphinx-jupyterbook-latex/_config.yml
@@ -1,0 +1,25 @@
+# Book settings
+# Learn more at https://jupyterbook.org/customize/config.html
+
+title: My sample book
+author: The Jupyter Book Community
+logo: logo.png
+
+# Force re-execution of notebooks on each build.
+# See https://jupyterbook.org/content/execute.html
+execute:
+  execute_notebooks: force
+
+# Define the name of the latex output file for PDF builds
+latex:
+  latex_documents:
+    targetname: book.tex
+
+bibtex_bibfiles:
+- references.bib
+
+sphinx:
+  extra_extensions:
+    - sphinx_jupyterbook_latex
+  config:
+    jblatex_captions_to_parts: true

--- a/tests/books/sphinx-jupyterbook-latex/_toc.yml
+++ b/tests/books/sphinx-jupyterbook-latex/_toc.yml
@@ -1,0 +1,17 @@
+format: jb-book
+root: intro
+parts:
+- caption: part1
+  chapters:
+  - file: part1/chap1.md
+  - file: part1/chap2
+    sections:
+    - file: part1/sec1
+    - file: part1/sec2.md
+- caption: part2
+  chapters:
+  - url: https://executablebooks.org/en/latest/gallery.html
+    title: Gallery of Jupyter Books
+  - file: part2/chap3
+    sections:
+    - file: part2/sec1

--- a/tests/books/sphinx-jupyterbook-latex/intro.md
+++ b/tests/books/sphinx-jupyterbook-latex/intro.md
@@ -1,0 +1,18 @@
+# This is the intro
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis vel nunc vestibulum, pretium urna ac, hendrerit diam. Nulla ut mi sit amet dui placerat tempor at quis magna. Sed porttitor blandit consequat. Fusce efficitur mi eget pharetra cursus. Sed vel blandit dui, et pharetra velit. Ut eget erat rutrum, maximus felis ullamcorper, congue urna. Ut pellentesque, orci vel consectetur aliquam, velit elit vehicula libero, eu blandit tellus risus rhoncus massa. Curabitur id libero ut sapien aliquet dapibus nec et dolor. Pellentesque tincidunt iaculis ipsum vitae pretium. Quisque et egestas orci, sed dignissim sem. Vestibulum sed commodo dui. Nulla rutrum vulputate nisl nec interdum. Cras pharetra quam et tellus convallis, ut hendrerit mi mollis. Integer finibus tellus porttitor tellus bibendum, a auctor purus dapibus. Etiam mauris est, blandit ut dapibus eget, rutrum et dolor.
+
+## This is H2
+
+Etiam interdum tempor augue at volutpat. Nulla sit amet volutpat elit. In vehicula dapibus velit, a placerat neque blandit et. Etiam non mollis nibh. Mauris tortor purus, semper vel libero at, faucibus mattis enim. Sed elit mi, vestibulum sit amet porttitor in, elementum a sem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec gravida faucibus enim, at venenatis ante. Curabitur viverra neque vel nulla condimentum ultrices quis a ipsum.
+
+```{tableofcontents}
+```
+
+### This is H3
+
+Sed elit mi, vestibulum sit amet porttitor in, elementum a sem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec gravida faucibus enim, at venenatis ante. Curabitur viverra neque vel nulla condimentum ultrices quis a ipsum.
+
+#### This is H4
+
+Ipso facto

--- a/tests/books/sphinx-jupyterbook-latex/part1/chap1.md
+++ b/tests/books/sphinx-jupyterbook-latex/part1/chap1.md
@@ -1,0 +1,3 @@
+# Chapter 1
+
+Chap 1 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.

--- a/tests/books/sphinx-jupyterbook-latex/part1/chap2.md
+++ b/tests/books/sphinx-jupyterbook-latex/part1/chap2.md
@@ -1,0 +1,11 @@
+# Chapter 2
+
+Chap 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.
+
+```{bibliography} ../references.bib
+```
+
+{cite}`perez2011python,holdgraf_rapid_2016,RePEc:the:publsh:1367,caporaso2010qiime`
+
+```{tableofcontents}
+```

--- a/tests/books/sphinx-jupyterbook-latex/part1/sec1.md
+++ b/tests/books/sphinx-jupyterbook-latex/part1/sec1.md
@@ -1,0 +1,3 @@
+# Section 1
+
+Sec 1 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.

--- a/tests/books/sphinx-jupyterbook-latex/part1/sec2.md
+++ b/tests/books/sphinx-jupyterbook-latex/part1/sec2.md
@@ -1,0 +1,3 @@
+# Section 2
+
+Sec 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.

--- a/tests/books/sphinx-jupyterbook-latex/part2/chap3.md
+++ b/tests/books/sphinx-jupyterbook-latex/part2/chap3.md
@@ -1,0 +1,7 @@
+# Chapter 3
+
+Chap 3 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.
+
+
+## Chap3 sub header
+Etiam quis cursus mi, fringilla aliquet ipsum. Nunc in lorem auctor, hendrerit lacus lobortis, ullamcorper velit. Phasellus turpis justo, tempus nec nibh ut, mattis consectetur lectus. Curabitur sem arcu, vulputate ut accumsan eget, ornare eu urna. Sed dapibus fermentum viverra.

--- a/tests/books/sphinx-jupyterbook-latex/part2/sec1.md
+++ b/tests/books/sphinx-jupyterbook-latex/part2/sec1.md
@@ -1,0 +1,3 @@
+# Section 1
+
+Sec 1 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris lacinia varius sapien, et aliquet justo. Fusce sodales, magna malesuada commodo ornare, mauris erat hendrerit augue, dictum luctus dolor quam eget tellus. Nulla porta nibh eros, gravida euismod lorem placerat et. Praesent pulvinar congue gravida.

--- a/tests/books/sphinx-jupyterbook-latex/references.bib
+++ b/tests/books/sphinx-jupyterbook-latex/references.bib
@@ -1,0 +1,48 @@
+@article{perez2011python
+,	title	= {Python: an ecosystem for scientific computing}
+,	author	= {Perez, Fernando and Granger, Brian E and Hunter, John D}
+,	journal	= {Computing in Science \\& Engineering}
+,	volume	= {13}
+,	number	= {2}
+,	pages	= {13--21}
+,	year	= {2011}
+,	publisher	= {AIP Publishing}
+}
+
+
+@article{holdgraf_rapid_2016,
+	title = {Rapid tuning shifts in human auditory cortex enhance speech intelligibility},
+	volume = {7},
+	issn = {2041-1723},
+	url = {http://www.nature.com/doifinder/10.1038/ncomms13654},
+	doi = {10.1038/ncomms13654},
+	number = {May},
+	journal = {Nature Communications},
+	author = {Holdgraf, Christopher Ramsay and de Heer, Wendy and Pasley, Brian N. and Rieger, Jochem W. and Crone, Nathan and Lin, Jack J. and Knight, Robert T. and Theunissen, Frédéric E.},
+	year = {2016},
+	pages = {13654},
+	file = {Holdgraf et al. - 2016 - Rapid tuning shifts in human auditory cortex enhance speech intelligibility.pdf:C\:\\Users\\chold\\Zotero\\storage\\MDQP3JWE\\Holdgraf et al. - 2016 - Rapid tuning shifts in human auditory cortex enhance speech intelligibility.pdf:application/pdf}
+}
+
+
+@article{RePEc:the:publsh:1367
+,	src	= {repec.org}
+,	title	= {Stochastic stability in monotone economies}
+,	author	= {Stachurski, John and Kamihigashi, Takashi}
+,	journal	= {Theoretical Economics}
+,	year	= {2014}
+,	volume	= {9}
+,	issue	= {2}
+}
+
+
+@article{caporaso2010qiime
+,	title	= {QIIME allows analysis of high-throughput community sequencing data}
+,	author	= {Caporaso, J Gregory and Kuczynski, Justin and Stombaugh, Jesse and Bittinger, Kyle and Bushman, Frederic D and Costello, Elizabeth K and Fierer, Noah and Pena, Antonio Gonzalez and Goodrich, Julia K and Gordon, Jeffrey I and others}
+,	journal	= {Nature methods}
+,	volume	= {7}
+,	number	= {5}
+,	pages	= {335--336}
+,	year	= {2010}
+,	publisher	= {Nature Publishing Group}
+}

--- a/tests/test_sphinx_jupyterbook_latex.py
+++ b/tests/test_sphinx_jupyterbook_latex.py
@@ -1,0 +1,31 @@
+import pickle
+
+import pytest
+from TexSoup import TexSoup
+
+from jupyter_book.cli.main import build
+
+
+@pytest.mark.requires_tex
+def test_toc(cli, build_resources, file_regression):
+    books, tocs = build_resources
+    path_parts_toc = books.joinpath("sphinx-jupyterbook-latex")
+    cmd = f"{path_parts_toc} --builder pdflatex"
+    result = cli.invoke(build, cmd.split())
+    assert result.exit_code == 0, result.output
+
+    # reading the tex file
+    path_output_file = path_parts_toc.joinpath("_build", "latex", "book.tex")
+    file_content = TexSoup(path_output_file.read_text())
+    file_regression.check(str(file_content.document), extension=".tex", encoding="utf8")
+
+    # reading the xml file
+    doctree_path = path_parts_toc.joinpath("_build", ".doctrees", "intro.doctree")
+    doc = pickle.load(open(doctree_path, "rb"))
+    pseudoxml = doc.pformat()
+
+    # to remove source attribute of document as it is a temp
+    index = pseudoxml.index("\n")
+    substr = pseudoxml[index:]
+    pseudoxml = "<document>" + substr
+    file_regression.check(str(pseudoxml), extension=".xml", encoding="utf8")

--- a/tests/test_sphinx_jupyterbook_latex/test_toc.tex
+++ b/tests/test_sphinx_jupyterbook_latex/test_toc.tex
@@ -1,0 +1,156 @@
+\begin{document}
+
+\pagestyle{empty}
+\sphinxmaketitle
+\pagestyle{plain}
+\sphinxtableofcontents
+\pagestyle{normal}
+\phantomsection\label{\detokenize{intro::doc}}
+
+
+\sphinxAtStartPar
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis vel nunc vestibulum, pretium urna ac, hendrerit diam. Nulla ut mi sit amet dui placerat tempor at quis magna. Sed porttitor blandit consequat. Fusce efficitur mi eget pharetra cursus. Sed vel blandit dui, et pharetra velit. Ut eget erat rutrum, maximus felis ullamcorper, congue urna. Ut pellentesque, orci vel consectetur aliquam, velit elit vehicula libero, eu blandit tellus risus rhoncus massa. Curabitur id libero ut sapien aliquet dapibus nec et dolor. Pellentesque tincidunt iaculis ipsum vitae pretium. Quisque et egestas orci, sed dignissim sem. Vestibulum sed commodo dui. Nulla rutrum vulputate nisl nec interdum. Cras pharetra quam et tellus convallis, ut hendrerit mi mollis. Integer finibus tellus porttitor tellus bibendum, a auctor purus dapibus. Etiam mauris est, blandit ut dapibus eget, rutrum et dolor.
+
+\begin{DUlineblock}{0em}
+\item[] \sphinxstylestrong{\Large This is H2}
+\end{DUlineblock}
+
+\sphinxAtStartPar
+Etiam interdum tempor augue at volutpat. Nulla sit amet volutpat elit. In vehicula dapibus velit, a placerat neque blandit et. Etiam non mollis nibh. Mauris tortor purus, semper vel libero at, faucibus mattis enim. Sed elit mi, vestibulum sit amet porttitor in, elementum a sem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec gravida faucibus enim, at venenatis ante. Curabitur viverra neque vel nulla condimentum ultrices quis a ipsum.
+\begin{itemize}
+\item{}
+\sphinxAtStartPar
+part1
+
+\begin{itemize}
+\item{}
+\sphinxAtStartPar{\hyperref[\detokenize{part1/chap1::doc}]{\sphinxcrossref{Chapter 1}}}
+
+\item{}
+\sphinxAtStartPar{\hyperref[\detokenize{part1/chap2::doc}]{\sphinxcrossref{Chapter 2}}}
+\begin{itemize}
+\item{}
+\sphinxAtStartPar{\hyperref[\detokenize{part1/sec1::doc}]{\sphinxcrossref{Section 1}}}
+
+\item{}
+\sphinxAtStartPar{\hyperref[\detokenize{part1/sec2::doc}]{\sphinxcrossref{Section 2}}}
+
+\end{itemize}
+
+\end{itemize}
+\end{itemize}
+\begin{itemize}
+\item{}
+\sphinxAtStartPar
+part2
+
+\begin{itemize}
+\item{}
+\sphinxAtStartPar
+\sphinxhref{https://executablebooks.org/en/latest/gallery.html}{Gallery of Jupyter Books}
+
+\item{}
+\sphinxAtStartPar{\hyperref[\detokenize{part2/chap3::doc}]{\sphinxcrossref{Chapter 3}}}
+
+\end{itemize}
+\end{itemize}
+
+\begin{DUlineblock}{0em}
+\item[] \sphinxstylestrong{\large This is H3}
+\end{DUlineblock}
+
+\sphinxAtStartPar
+Sed elit mi, vestibulum sit amet porttitor in, elementum a sem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec gravida faucibus enim, at venenatis ante. Curabitur viverra neque vel nulla condimentum ultrices quis a ipsum.
+
+\begin{DUlineblock}{0em}
+\item[] \sphinxstylestrong{\large This is H4}
+\end{DUlineblock}
+
+\sphinxAtStartPar
+Ipso facto
+
+
+\part{part1}
+
+
+\chapter{Chapter 1}
+\label{\detokenize{part1/chap1:chapter-1}}\label{\detokenize{part1/chap1::doc}}
+\sphinxAtStartPar
+Chap 1 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.
+
+
+\chapter{Chapter 2}
+\label{\detokenize{part1/chap2:chapter-2}}\label{\detokenize{part1/chap2::doc}}
+\sphinxAtStartPar
+Chap 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.
+
+\sphinxAtStartPar
+
+
+\sphinxAtStartPar{[}\hyperlink{cite.part1/chap2:id5}{CKS+10}, \hyperlink{cite.part1/chap2:id3}{HdHP+16}, \hyperlink{cite.part1/chap2:id2}{PGH11}, \hyperlink{cite.part1/chap2:id4}{SK14}{]}
+\begin{itemize}
+\item{}
+\sphinxAtStartPar{\hyperref[\detokenize{part1/sec1::doc}]{\sphinxcrossref{Section 1}}}
+
+\item{}
+\sphinxAtStartPar{\hyperref[\detokenize{part1/sec2::doc}]{\sphinxcrossref{Section 2}}}
+
+\end{itemize}
+
+
+\section{Section 1}
+\label{\detokenize{part1/sec1:section-1}}\label{\detokenize{part1/sec1::doc}}
+\sphinxAtStartPar
+Sec 1 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.
+
+
+\section{Section 2}
+\label{\detokenize{part1/sec2:section-2}}\label{\detokenize{part1/sec2::doc}}
+\sphinxAtStartPar
+Sec 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.
+
+
+\part{part2}
+
+
+\chapter{Chapter 3}
+\label{\detokenize{part2/chap3:chapter-3}}\label{\detokenize{part2/chap3::doc}}
+\sphinxAtStartPar
+Chap 3 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.
+
+
+\section{Chap3 sub header}
+\label{\detokenize{part2/chap3:chap3-sub-header}}
+\sphinxAtStartPar
+Etiam quis cursus mi, fringilla aliquet ipsum. Nunc in lorem auctor, hendrerit lacus lobortis, ullamcorper velit. Phasellus turpis justo, tempus nec nibh ut, mattis consectetur lectus. Curabitur sem arcu, vulputate ut accumsan eget, ornare eu urna. Sed dapibus fermentum viverra.
+
+
+\section{Section 1}
+\label{\detokenize{part2/sec1:section-1}}\label{\detokenize{part2/sec1::doc}}
+\sphinxAtStartPar
+Sec 1 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris lacinia varius sapien, et aliquet justo. Fusce sodales, magna malesuada commodo ornare, mauris erat hendrerit augue, dictum luctus dolor quam eget tellus. Nulla porta nibh eros, gravida euismod lorem placerat et. Praesent pulvinar congue gravida.
+
+\begin{sphinxthebibliography}{HdHP+16}
+\bibitem[CKS+10]{part1/chap2:id5}
+\sphinxAtStartPar
+J Gregory Caporaso, Justin Kuczynski, Jesse Stombaugh, Kyle Bittinger, Frederic D Bushman, Elizabeth K Costello, Noah Fierer, Antonio Gonzalez Pena, Julia K Goodrich, Jeffrey I Gordon, and others. Qiime allows analysis of high\sphinxhyphen{}throughput community sequencing data. \sphinxstyleemphasis{Nature methods}, 7(5):335–336, 2010.
+\bibitem[HdHP+16]{part1/chap2:id3}
+\sphinxAtStartPar
+Christopher Ramsay Holdgraf, Wendy de Heer, Brian N. Pasley, Jochem W. Rieger, Nathan Crone, Jack J. Lin, Robert T. Knight, and Frédéric E. Theunissen. Rapid tuning shifts in human auditory cortex enhance speech intelligibility. \sphinxstyleemphasis{Nature Communications}, 7(May):13654, 2016. URL: \sphinxurl{http://www.nature.com/doifinder/10.1038/ncomms13654}, \sphinxhref{https://doi.org/10.1038/ncomms13654}{doi:10.1038/ncomms13654}.
+\bibitem[PGH11]{part1/chap2:id2}
+\sphinxAtStartPar
+Fernando Perez, Brian E Granger, and John D Hunter. Python: an ecosystem for scientific computing. \sphinxstyleemphasis{Computing in Science \textbackslash{}\textbackslash{}\& Engineering}, 13(2):13–21, 2011.
+\bibitem[SK14]{part1/chap2:id4}
+\sphinxAtStartPar
+John Stachurski and Takashi Kamihigashi. Stochastic stability in monotone economies. \sphinxstyleemphasis{Theoretical Economics}, 2014.
+\end{sphinxthebibliography}
+
+
+
+
+
+
+
+\renewcommand{\indexname}{Index}
+\printindex
+\end{document}

--- a/tests/test_sphinx_jupyterbook_latex/test_toc.xml
+++ b/tests/test_sphinx_jupyterbook_latex/test_toc.xml
@@ -1,0 +1,27 @@
+<document>
+    <section classes="tex2jax_ignore mathjax_ignore" docname="intro" header_level="1" ids="this-is-the-intro" names="this\ is\ the\ intro">
+        <title>
+            This is the intro
+        <paragraph>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis vel nunc vestibulum, pretium urna ac, hendrerit diam. Nulla ut mi sit amet dui placerat tempor at quis magna. Sed porttitor blandit consequat. Fusce efficitur mi eget pharetra cursus. Sed vel blandit dui, et pharetra velit. Ut eget erat rutrum, maximus felis ullamcorper, congue urna. Ut pellentesque, orci vel consectetur aliquam, velit elit vehicula libero, eu blandit tellus risus rhoncus massa. Curabitur id libero ut sapien aliquet dapibus nec et dolor. Pellentesque tincidunt iaculis ipsum vitae pretium. Quisque et egestas orci, sed dignissim sem. Vestibulum sed commodo dui. Nulla rutrum vulputate nisl nec interdum. Cras pharetra quam et tellus convallis, ut hendrerit mi mollis. Integer finibus tellus porttitor tellus bibendum, a auctor purus dapibus. Etiam mauris est, blandit ut dapibus eget, rutrum et dolor.
+        <section docname="intro" header_level="2" ids="this-is-h2" names="this\ is\ h2">
+            <title>
+                This is H2
+            <paragraph>
+                Etiam interdum tempor augue at volutpat. Nulla sit amet volutpat elit. In vehicula dapibus velit, a placerat neque blandit et. Etiam non mollis nibh. Mauris tortor purus, semper vel libero at, faucibus mattis enim. Sed elit mi, vestibulum sit amet porttitor in, elementum a sem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec gravida faucibus enim, at venenatis ante. Curabitur viverra neque vel nulla condimentum ultrices quis a ipsum.
+            <HiddenCellNode caption="part1" classes="latex-tableofcontents" entries="(None,\ 'part1/chap1') (None,\ 'part1/chap2')" glob="False" hidden="False" includefiles="part1/chap1 part1/chap2" includehidden="False" maxdepth="-1" numbered="0" parent="intro" rawcaption="part1" titlesonly="True">
+            <compound caption="part1" classes="toctree-wrapper" docname="intro">
+                <toctree caption="part1" classes="latex-tableofcontents" entries="(None,\ 'part1/chap1') (None,\ 'part1/chap2')" glob="False" hidden="False" includefiles="part1/chap1 part1/chap2" includehidden="False" maxdepth="-1" numbered="0" parent="intro" rawcaption="part1" titlesonly="True">
+            <HiddenCellNode caption="part2" classes="latex-tableofcontents" entries="('Gallery\ of\ Jupyter\ Books',\ 'https://executablebooks.org/en/latest/gallery.html') (None,\ 'part2/chap3')" glob="False" hidden="False" includefiles="part2/chap3" includehidden="False" maxdepth="-1" numbered="0" parent="intro" rawcaption="part2" titlesonly="True">
+            <compound caption="part2" classes="toctree-wrapper" docname="intro">
+                <toctree caption="part2" classes="latex-tableofcontents" entries="('Gallery\ of\ Jupyter\ Books',\ 'https://executablebooks.org/en/latest/gallery.html') (None,\ 'part2/chap3')" glob="False" hidden="False" includefiles="part2/chap3" includehidden="False" maxdepth="-1" numbered="0" parent="intro" rawcaption="part2" titlesonly="True">
+            <section docname="intro" header_level="3" ids="this-is-h3" names="this\ is\ h3">
+                <title>
+                    This is H3
+                <paragraph>
+                    Sed elit mi, vestibulum sit amet porttitor in, elementum a sem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec gravida faucibus enim, at venenatis ante. Curabitur viverra neque vel nulla condimentum ultrices quis a ipsum.
+                <section docname="intro" header_level="4" ids="this-is-h4" names="this\ is\ h4">
+                    <title>
+                        This is H4
+                    <paragraph>
+                        Ipso facto


### PR DESCRIPTION
This PR migrates a test case from [sphinx-jupyterbook-latex](https://github.com/executablebooks/sphinx-jupyterbook-latex) extension for testing integration with `jupyter-book`. This allows `sphinx-jupyterbook-latex` to have no reliance on `jupyter-book` which is upstream to `sphinx-jupyterbook-latex`. 

This migration is part of the `sphinx4` upgrade to the software stack. 

https://github.com/executablebooks/sphinx-jupyterbook-latex/pull/75#issuecomment-923484080