### PR TITLE
pin jsonschema

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ packages = find:
 install_requires =
     click
     docutils>=0.15,<0.17
-    jsonschema
+    jsonschema<4
     # Include Jupytext to ensure users have the right version, even if not strictly necessary
     jupytext>=1.8,<1.11
     linkify-it-py~=1.0.1


### PR DESCRIPTION
This resolves #1483 by pinning the `jsonschema` package to below the latest release (it was unpinned before). Longer term we should update the pin and fix the warning described in #1483 but this gets our tests to passing for now.

Unless there's an objection and assuming tests are happy, I'll merge this in without review (though happy to have a review if someone has the time) since the fix is simple and it un-breaks our tests on master.