### PR TITLE
DOCS: update start/overview section on _toc.yml

### DIFF
--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -150,8 +150,7 @@ The `_toc.yml` is arranged with a `format` such as `jb-article`, or `jb-book`.
 The `root` item is considered the landing page (for `html` builds) and is used as front matter (for `latex` builds).
 For `jb-book`, subsequent chapters can be added under the `chapters:` section in the `yml` file.
 
-Each entry relates to a file and they should be added as names with **no extensions**
-and **relative to your book's folder and with no extension.**
+Each entry relates to a file, and they should be added as names with **no extensions** and **relative to your book's root folder.**
 The title of each chapter will be inferred from the title in your files.
 
 :::{admonition} More about `_toc.yml`


### PR DESCRIPTION
This PR closes #1515 and updates the docs using the new `_toc.yml` structure. 