### PR TITLE
docs: add (`_toc.yml`) after "Table of Contents"

### DIFF
--- a/docs/start/create.md
+++ b/docs/start/create.md
@@ -129,7 +129,7 @@ Check out the other content in your configuration file, and reference it against
 
 ## Your book's table of contents
 
-Finally, your book also has a **Table of Contents** that tells Jupyter Book where each of your content source files should go.
+Finally, your book also has a **Table of Contents** (`_toc.yml`) that tells Jupyter Book where each of your content source files should go.
 
 ```yaml
 format: jb-book


### PR DESCRIPTION
I just went through this nice example and suggest to add the correct filename for the **Table of Contents** here as done for the config file above too.