### PR TITLE
MAINT: Upgrade to sphinx-jupyterbook-latex~=0.4.6

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,10 +3,7 @@ version: 2
 python:
   version: "3.8"
   install:
-      - method: pip
-        path: .
-        extra_requirements:
-        - "sphinx==4.2"
+  - requirements: docs/requirements.txt
 
 sphinx:
   builder: html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,10 @@ version: 2
 python:
   version: "3.8"
   install:
-  - requirements: docs/requirements.txt
+  - method: pip
+    path: .
+    extra_requirements:
+    - sphinx
 
 sphinx:
   builder: html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ python:
       - method: pip
         path: .
         extra_requirements:
-        - sphinx
+        - sphinx<=4.2
 
 sphinx:
   builder: html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ python:
       - method: pip
         path: .
         extra_requirements:
-        - sphinx==4.2
+        - "sphinx==4.2"
 
 sphinx:
   builder: html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ python:
       - method: pip
         path: .
         extra_requirements:
-        - sphinx<=4.2
+        - sphinx==4.2
 
 sphinx:
   builder: html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,10 +3,10 @@ version: 2
 python:
   version: "3.8"
   install:
-  - method: pip
-    path: .
-    extra_requirements:
-    - sphinx
+    - method: pip
+      path: .
+      extra_requirements:
+      - sphinx
 
 sphinx:
   builder: html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 # Copied from 'sphinx' extra of setup.cfg
+sphinx>=3,<4.3
 altair
 bokeh
 folium

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 # Copied from 'sphinx' extra of setup.cfg
-sphinx>=3,<4.3
 altair
 bokeh
 folium

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     sphinx-comments
     sphinx-copybutton
     sphinx-external-toc~=0.2.3
-    sphinx-jupyterbook-latex~=0.4.3
+    sphinx-jupyterbook-latex~=0.4.6
     sphinx-panels~=0.6.0
     sphinx-thebe~=0.0.10
     sphinx_book_theme~=0.1.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     linkify-it-py~=1.0.1
     myst-nb~=0.13.1
     pyyaml
-    sphinx>=3,<5
+    sphinx>=3,<4.3
     sphinx-comments
     sphinx-copybutton
     sphinx-external-toc~=0.2.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     linkify-it-py~=1.0.1
     myst-nb~=0.13.1
     pyyaml
-    sphinx>=3,<4.3
+    sphinx>=3,<5
     sphinx-comments
     sphinx-copybutton
     sphinx-external-toc~=0.2.3
@@ -69,6 +69,8 @@ code_style =
 pdfhtml =
     pyppeteer
 sphinx =
+    # Remove sphinx>=4.3 once pydata-sphinx-theme has been updated
+    sphinx>=3,<4.3
     altair
     bokeh
     folium

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,8 +69,6 @@ code_style =
 pdfhtml =
     pyppeteer
 sphinx =
-    # Remove sphinx>=4.3 once pydata-sphinx-theme has been updated
-    sphinx>=3,<4.3
     altair
     bokeh
     folium

--- a/tests/test_build/_toc_numbered_depth_parts_subset.sphinx4.html
+++ b/tests/test_build/_toc_numbered_depth_parts_subset.sphinx4.html
@@ -7,7 +7,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 1
    </span>
@@ -19,7 +19,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 2
    </span>
@@ -36,7 +36,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 3
    </span>

--- a/tests/test_build/_toc_numbered_parts.sphinx4.html
+++ b/tests/test_build/_toc_numbered_parts.sphinx4.html
@@ -7,7 +7,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 1
    </span>
@@ -37,7 +37,7 @@
     </input>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 2
    </span>

--- a/tests/test_build/_toc_numbered_parts_subset.sphinx4.html
+++ b/tests/test_build/_toc_numbered_parts_subset.sphinx4.html
@@ -7,7 +7,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 1
    </span>
@@ -19,7 +19,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 2
    </span>
@@ -36,7 +36,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 3
    </span>

--- a/tests/test_sphinx_multitoc_numbering/_toc_numbered_depth_parts_subset_multitoc_numbering_false.sphinx4.html
+++ b/tests/test_sphinx_multitoc_numbering/_toc_numbered_depth_parts_subset_multitoc_numbering_false.sphinx4.html
@@ -7,7 +7,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 1
    </span>
@@ -19,7 +19,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 2
    </span>
@@ -36,7 +36,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 3
    </span>

--- a/tests/test_sphinx_multitoc_numbering/_toc_numbered_parts_multitoc_numbering_false.sphinx4.html
+++ b/tests/test_sphinx_multitoc_numbering/_toc_numbered_parts_multitoc_numbering_false.sphinx4.html
@@ -7,7 +7,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 1
    </span>
@@ -37,7 +37,7 @@
     </input>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 2
    </span>

--- a/tests/test_sphinx_multitoc_numbering/_toc_numbered_parts_subset_multitoc_numbering_false.sphinx4.html
+++ b/tests/test_sphinx_multitoc_numbering/_toc_numbered_parts_subset_multitoc_numbering_false.sphinx4.html
@@ -7,7 +7,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 1
    </span>
@@ -19,7 +19,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 2
    </span>
@@ -36,7 +36,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Chapter 3
    </span>

--- a/tests/test_tocdirective/test_toc_parts_directive.sphinx4.html
+++ b/tests/test_tocdirective/test_toc_parts_directive.sphinx4.html
@@ -1,5 +1,5 @@
 <div class="toctree-wrapper compound">
- <p class="caption" role="heading">
+ <p aria-level="2" class="caption" role="heading">
   <span class="caption-text">
    A section
   </span>

--- a/tests/test_tocdirective/test_toc_parts_sidebar.sphinx4.html
+++ b/tests/test_tocdirective/test_toc_parts_sidebar.sphinx4.html
@@ -7,7 +7,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     A section
    </span>
@@ -32,7 +32,7 @@
     </input>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Another section
    </span>


### PR DESCRIPTION
This PR:

1. updates to `sphinx-jupyterbook-latex==0.4.6`
2. updates fixtures for `sphinx>=4.3` due to deprecation changes and adjustments in `pydata-sphinx-theme`

This update incorporates:

## 0.4.6 - 2021-11-05

### ✨ NEW

- Formatting of output code cells
- Adding chapter numbers in equations

### 👌 IMPROVE

- Refactored and added tests

## 0.4.5 - 2021-10-20

### 👌 IMPROVE

- Added some macros in class file to better support math intensive lectures.

## 0.4.4 - 2021-10-06

### 🐛 FIX

- Addresses missing hidden toctree attribute [PR #74](https://github.com/executablebooks/sphinx-jupyterbook-latex/pull/74)
  Thanks to @Jegp and @xmnlab.