### PR TITLE
RELEASE: Setup and Changes for v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## v0.12.1
+
+This release provides bug fixes and updates when building PDF via LaTeX including improved styling for
+code output cells. It also includes infrastructure for using Jupyter Book with ReadTheDocs.
+
+## New
+
+- ✨ NEW: Allow running on ReadTheDocs [PR #1422](https://github.com/executablebooks/jupyter-book/pull/1422)
+- ✨ NEW: Upgrade to sphinx-jupyterbook-latex~=0.4.6 [PR #1538](https://github.com/executablebooks/jupyter-book/pull/1538)
+
 ## v0.12.0
 
 ### New

--- a/jupyter_book/__init__.py
+++ b/jupyter_book/__init__.py
@@ -1,7 +1,7 @@
 """Build a book with Jupyter Notebooks and Sphinx."""
 from pathlib import Path
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 
 def add_static_files(app, config):


### PR DESCRIPTION
This PR sets up `jupyter-book` for v0.12.1 release