### PR TITLE
DOC: add back conda forge in intro

### DIFF
--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -24,6 +24,11 @@ You can install Jupyter Book [via `pip`](https://pip.pypa.io/en/stable/):
 ```bash
 pip install -U jupyter-book
 ```
+or via [`conda-forge`](https://conda-forge.org/):
+
+```bash
+conda install -c conda-forge jupyter-book
+```
 
 This will install everything you need to build a Jupyter Book locally.
 


### PR DESCRIPTION
Hi, 

This is a very small change to the docs which adds back the install instructions for conda. It appears that this was previously in the documentation but then removed because it was not working: https://github.com/executablebooks/jupyter-book/pull/1034

And according to this issue, I think it was resolved: 
https://github.com/executablebooks/jupyter-book/issues/1035

The one piece that is not clear to me is if building PDFs is still an issue with jupyter-book conda (see: https://github.com/conda-forge/staged-recipes/pull/12516#discussion_r502814168). If so, maybe I should add a note?

Thanks for this great project. 

Vin