### PR TITLE
[DOCS] Add mention of singlehtml builder

### DIFF
--- a/docs/customize/toc.md
+++ b/docs/customize/toc.md
@@ -156,8 +156,8 @@ The primary difference is that the `jb-book` format uses `parts:` and `chapters:
 
 To build an article (or a book) that is comprised of multiple files
 so that it is rendered as a single HTML document containing all the content,
-you can use of the 
-[singlehtml builder](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.singlehtml.SingleFileHTMLBuilder). 
+you can use of the
+[singlehtml builder](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.singlehtml.SingleFileHTMLBuilder).
 
 For example:
 

--- a/docs/customize/toc.md
+++ b/docs/customize/toc.md
@@ -154,10 +154,7 @@ sections:
 
 The primary difference is that the `jb-book` format uses `parts:` and `chapters:` syntax, while the `jb-article` format uses `sections:` syntax alone.
 
-To build an article (or a book) that is comprised of multiple files
-so that it is rendered as a single HTML document containing all the content,
-you can use of the
-[singlehtml builder](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.singlehtml.SingleFileHTMLBuilder).
+To build a single HTML page from these files (rather than one page per file), use the [singlehtml builder](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.singlehtml.SingleFileHTMLBuilder).
 
 For example:
 

--- a/docs/customize/toc.md
+++ b/docs/customize/toc.md
@@ -154,6 +154,17 @@ sections:
 
 The primary difference is that the `jb-book` format uses `parts:` and `chapters:` syntax, while the `jb-article` format uses `sections:` syntax alone.
 
+To build an article (or a book) that is comprised of multiple files
+so that it is rendered as a single HTML document containing all the content,
+you can use of the 
+[singlehtml builder](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.singlehtml.SingleFileHTMLBuilder). 
+
+For example:
+
+```bash
+jupyter-book build path/to/book --builder singlehtml
+```
+
 ## Types of content entries
 
 There are several types of entries that you may provide in order to point to specific types of content.


### PR DESCRIPTION
This PR adds mention of singlehtml builder in the Jupyter book docs in `docs/customize/toc.md` 
under the `### Build an article from multiple files` heading. 
Not sure if this is the most appropriate place, but this is where I went when I was looking for docs on this.

Closes #1554 