### PR TITLE
Add missing quotes to notebook metadata example

### DIFF
--- a/docs/content/execute.md
+++ b/docs/content/execute.md
@@ -190,7 +190,7 @@ This global value can also be overridden per notebook by adding this to your not
 {
  "metadata": {
   "execution": {
-      "allow_errors": false
+      "allow_errors": "false"
   }
 }
 ```


### PR DESCRIPTION
It seems like the option to enable or disable errors via notebook metadata needs to be a string and not a boolean (see error below). Updated the example to correctly quote the option to make it work. I am using Jupyter-Book v0.12.0
```
nbformat.validator.NotebookValidationError: False is not of type 'string'

Failed validating 'type' in code_cell['properties']['metadata']['properties']['execution']['patternProperties']['^.*$']:

On instance['cells'][4]['metadata']['execution']['allow_errors']:
False
```