### PR TITLE
DOC: Update header references title

### DIFF
--- a/docs/content/references.md
+++ b/docs/content/references.md
@@ -43,7 +43,7 @@ For example, we've added the following label above the header for this section w
 
 ```md
 (content:references:labels)=
-## Cross-references and labels
+## Reference section labels
 ```
 
 You can insert cross-references to labels in your content with two kinds of syntax:


### PR DESCRIPTION
Apologies in advance for consuming review cycles for such a minor fix. I thought I misunderstood the documentation and figured I'd send the correction in case others get confused. In the doc, the section being referenced is: `Reference section labels`  but the documentation names the section as `Cross-references and labels`.