### PR TITLE
DOCS: Update pre commit jupyter book version

### DIFF
--- a/docs/sphinx/index.md
+++ b/docs/sphinx/index.md
@@ -63,7 +63,7 @@ Follow these steps to use a `pre-commit` hook that converts your Jupyter Book in
    ```yaml
    repos:
    - repo: https://github.com/executablebooks/jupyter-book
-     rev: v0.11.2
+     rev: v0.12.1
      hooks:
      - id: jb-to-sphinx
        args: ["path/to/book"]


### PR DESCRIPTION
With the current version listed, I get an error "InvalidManifestError". This was fixed once I updated the version, but it took me a while to figure out what was going wrong.