### PR TITLE
DOC: Clarify numbered references for sections

### DIFF
--- a/docs/content/references.md
+++ b/docs/content/references.md
@@ -208,11 +208,13 @@ If you are [using custom text](references:custom-text) with your references, use
 
 ::::{admonition} Example
 **Markdown**
+
 ```md
 Here's {numref}`Custom Table %s text <my-table-ref>`.
 ```
 
 **Result**
+
 Here's {numref}`Custom Table %s text <my-table-ref>`.
 ::::
 

--- a/docs/content/references.md
+++ b/docs/content/references.md
@@ -199,10 +199,31 @@ For example, see the following references:
 
 ## Number your references
 
-You can add **numbered references** to either [tables](references:tables) or [figures](references:figures). To add a numbered reference to a table or figure, use the `{numref}` role. If you wish to [use custom text](references:custom-text), add `%s` as a placeholder for the number.
+You can add **numbered references** to [tables](references:tables), [figures](references:figures), or [sections](references:numbered-sectinos).
+To add a numbered reference to a table or figure, use the `{numref}` role.
 
-See the examples in each section below for usage.
+### Use custom text with numbered references
 
+If you are [using custom text](references:custom-text) with your references, use `%s` as a placeholder for the number.
+
+::::{admonition} Example
+:::{list-table}
+* - Markdown
+  - Result
+* - ```md
+    Here's {numref}`My figure number %s <my-table-ref>`.
+    ```
+  - Here's {numref}`My figure number %s <my-table-ref>`.
+:::
+::::
+
+See more examples in the sections linked above.
+
+(references:numbered-sections)=
+### Reference numbered sections
+
+To reference numbered sections, you should first [enable numbered sections in your Table of Contents](toc/numbering).
+Then, you may use the `{numref}` role in the same way that you use it for Figures or Tables.
 
 (references:markdown-syntax)=
 ## Reference with markdown link syntax

--- a/docs/content/references.md
+++ b/docs/content/references.md
@@ -127,7 +127,7 @@ Here are several ways to reference this content:
 | `` Here is [](my-table-ref) ``               | Here is [](my-table-ref)               |
 | `` Here is [My cool table](my-table-ref) `` | Here is [My cool table](my-table-ref)              |
 | `` Here is {numref}`my-table-ref` ``            | Here is {numref}`my-table-ref`            |
-| `` Here is {numref}`Custom Table %s text ` `` | Here is {numref}`Custom Table %s text <my-table-ref>` |
+| `` Here is {numref}`Custom Table %s text <my-table-ref>` `` | Here is {numref}`Custom Table %s text <my-table-ref>` |
 
 
 ## Reference content files
@@ -207,14 +207,13 @@ To add a numbered reference to a table or figure, use the `{numref}` role.
 If you are [using custom text](references:custom-text) with your references, use `%s` as a placeholder for the number.
 
 ::::{admonition} Example
-:::{list-table}
-* - Markdown
-  - Result
-* - ```md
-    Here's {numref}`My figure number %s <my-table-ref>`.
-    ```
-  - Here's {numref}`My figure number %s <my-table-ref>`.
-:::
+**Markdown**
+```md
+Here's {numref}`Custom Table %s text <my-table-ref>`.
+```
+
+**Result**
+Here's {numref}`Custom Table %s text <my-table-ref>`.  
 ::::
 
 See more examples in the sections linked above.

--- a/docs/content/references.md
+++ b/docs/content/references.md
@@ -207,11 +207,13 @@ To add a numbered reference to a table or figure, use the `{numref}` role.
 If you are [using custom text](references:custom-text) with your references, use `%s` as a placeholder for the number.
 
 ::::{admonition} Example
-**Markdown**
-
 Markdown
 : ```md
   Here's {numref}`Custom Table %s text <my-table-ref>`.
+  ```
+
+Result
+: Here's {numref}`Custom Table %s text <my-table-ref>`.
 ::::
 
 See more examples in the sections linked above.

--- a/docs/content/references.md
+++ b/docs/content/references.md
@@ -213,7 +213,7 @@ Here's {numref}`Custom Table %s text <my-table-ref>`.
 ```
 
 **Result**
-Here's {numref}`Custom Table %s text <my-table-ref>`.  
+Here's {numref}`Custom Table %s text <my-table-ref>`.
 ::::
 
 See more examples in the sections linked above.

--- a/docs/content/references.md
+++ b/docs/content/references.md
@@ -209,13 +209,9 @@ If you are [using custom text](references:custom-text) with your references, use
 ::::{admonition} Example
 **Markdown**
 
-```md
-Here's {numref}`Custom Table %s text <my-table-ref>`.
-```
-
-**Result**
-
-Here's {numref}`Custom Table %s text <my-table-ref>`.
+Markdown
+: ```md
+  Here's {numref}`Custom Table %s text <my-table-ref>`.
 ::::
 
 See more examples in the sections linked above.

--- a/docs/content/references.md
+++ b/docs/content/references.md
@@ -199,7 +199,7 @@ For example, see the following references:
 
 ## Number your references
 
-You can add **numbered references** to [tables](references:tables), [figures](references:figures), or [sections](references:numbered-sectinos).
+You can add **numbered references** to [tables](references:tables), [figures](references:figures), or [sections](references:numbered-sections).
 To add a numbered reference to a table or figure, use the `{numref}` role.
 
 ### Use custom text with numbered references

--- a/docs/content/references.md
+++ b/docs/content/references.md
@@ -207,13 +207,15 @@ To add a numbered reference to a table or figure, use the `{numref}` role.
 If you are [using custom text](references:custom-text) with your references, use `%s` as a placeholder for the number.
 
 ::::{admonition} Example
-Markdown
-: ```md
-  Here's {numref}`Custom Table %s text <my-table-ref>`.
-  ```
+**Markdown**:
 
-Result
-: Here's {numref}`Custom Table %s text <my-table-ref>`.
+```md
+Here's {numref}`Custom Table %s text <my-table-ref>`.
+```
+
+**Result**:
+
+Here's {numref}`Custom Table %s text <my-table-ref>`.
 ::::
 
 See more examples in the sections linked above.


### PR DESCRIPTION
Clarifies some confusion that was noted in https://github.com/executablebooks/jupyter-book/issues/1119



I'll say it closes https://github.com/executablebooks/jupyter-book/issues/1119 since that issue was a bit stale, and I think this helps clarify it