### PR TITLE
[ENH] Add tag to cli for "only" content

### DIFF
--- a/jupyter_book/cli/main.py
+++ b/jupyter_book/cli/main.py
@@ -125,6 +125,12 @@ BUILDER_OPTS = {
     "https://www.sphinx-doc.org/en/master/man/sphinx-build.html",
 )
 @click.option(
+    "--tag",
+    multiple=True,
+    default=None,
+    help="Identify tag for including conditional content using the only directive.",
+)
+@click.option(
     "-v", "--verbose", count=True, help="increase verbosity (can be repeated)"
 )
 @click.option(
@@ -150,6 +156,7 @@ def build(
     freshenv,
     builder,
     custom_builder,
+    tag,
     verbose,
     quiet,
     individualpages,
@@ -302,6 +309,10 @@ def build(
         click.style("Output Path: ", bold=True, fg="blue")
         + click.format_filename(f"{OUTPUT_PATH}")
     )
+    click.echo(
+        click.style("Including tag: ", bold=True, fg="blue")
+        + click.style(f"{tag}")
+    )
 
     # Now call the Sphinx commands to build
     result = build_sphinx(
@@ -312,6 +323,7 @@ def build(
         path_config=path_config,
         confoverrides=config_overrides,
         builder=BUILDER_OPTS[builder],
+        tags=tag,
         warningiserror=warningiserror,
         keep_going=keep_going,
         freshenv=freshenv,

--- a/jupyter_book/cli/main.py
+++ b/jupyter_book/cli/main.py
@@ -310,8 +310,7 @@ def build(
         + click.format_filename(f"{OUTPUT_PATH}")
     )
     click.echo(
-        click.style("Including tag: ", bold=True, fg="blue")
-        + click.style(f"{tag}")
+        click.style("Including tag: ", bold=True, fg="blue") + click.style(f"{tag}")
     )
 
     # Now call the Sphinx commands to build

--- a/tests/pages/single_page.ipynb
+++ b/tests/pages/single_page.ipynb
@@ -48,6 +48,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Conditional content\n",
+    "## Single tag\n",
+    "\n",
+    "The only directive can use a single tag:\n",
+    "\n",
+    "```{only} cowboy\n",
+    "This note is not for city slickers!\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Boolean tag\n",
+    "\n",
+    "And you can use multiple tags:\n",
+    "\n",
+    "```{only} cowboy and cowgirl\n",
+    "This note is for cowboys and cowgirls!\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Python and outputs"
    ]
   },

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -315,7 +315,6 @@ def test_only(pages, cli):
     """Test {only} content is not built."""
     page = pages.joinpath("single_page.ipynb")
     html = pages.joinpath("_build", "_page", "single_page", "html")
-    index = html.joinpath("index.html")
     result = cli.invoke(commands.build, [page.as_posix(), "-n", "-W", "--keep-going"])
     assert result.exit_code == 0, result.output
     assert html.joinpath("single_page.html").exists()
@@ -329,7 +328,6 @@ def test_only_tag(pages, cli):
     """Test tag cli builds {only} content."""
     page = pages.joinpath("single_page.ipynb")
     html = pages.joinpath("_build", "_page", "single_page", "html")
-    index = html.joinpath("index.html")
     result = cli.invoke(
         commands.build, [page.as_posix(), "-n", "-W", "--keep-going", "--tag", "cowboy"]
     )
@@ -345,7 +343,6 @@ def test_both_tags(pages, cli):
     """Test multiple tag creates boolean condition."""
     page = pages.joinpath("single_page.ipynb")
     html = pages.joinpath("_build", "_page", "single_page", "html")
-    index = html.joinpath("index.html")
     result = cli.invoke(
         commands.build,
         [

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -309,3 +309,42 @@ def test_toc_numbered(
         basename=toc_file.split(".")[0],
         extension=f"{SPHINX_VERSION}.html",
     )
+
+def test_only(pages, cli):
+    """Test {only} content is not built."""
+    page = pages.joinpath("single_page.ipynb")
+    html = pages.joinpath("_build", "_page", "single_page", "html")
+    index = html.joinpath("index.html")
+    result = cli.invoke(commands.build, [page.as_posix(), "-n", "-W", "--keep-going"])
+    assert result.exit_code == 0, result.output
+    assert html.joinpath("single_page.html").exists()
+    outpage = html.joinpath("single_page.html")
+    assert not html.joinpath("extra_page.html").exists()
+    assert 'slickers' not in outpage.read_text(encoding="utf8")
+    assert 'cowgirls' not in outpage.read_text(encoding="utf8")
+
+def test_only_tag(pages, cli):
+    """Test tag cli builds {only} content."""
+    page = pages.joinpath("single_page.ipynb")
+    html = pages.joinpath("_build", "_page", "single_page", "html")
+    index = html.joinpath("index.html")
+    result = cli.invoke(commands.build, [page.as_posix(), "-n", "-W", "--keep-going", "--tag", "cowboy"])
+    assert result.exit_code == 0, result.output
+    assert html.joinpath("single_page.html").exists()
+    outpage = html.joinpath("single_page.html")
+    assert not html.joinpath("extra_page.html").exists()
+    assert 'slickers' in outpage.read_text(encoding="utf8")
+    assert 'cowgirls' not in outpage.read_text(encoding="utf8")
+
+def test_both_tags(pages, cli):
+    """Test multiple tag creates boolean condition."""
+    page = pages.joinpath("single_page.ipynb")
+    html = pages.joinpath("_build", "_page", "single_page", "html")
+    index = html.joinpath("index.html")
+    result = cli.invoke(commands.build, [page.as_posix(), "-n", "-W", "--keep-going", "--tag", "cowboy", "--tag", "cowgirl"])
+    assert result.exit_code == 0, result.output
+    assert html.joinpath("single_page.html").exists()
+    outpage = html.joinpath("single_page.html")
+    assert not html.joinpath("extra_page.html").exists()
+    assert 'slickers' in outpage.read_text(encoding="utf8")
+    assert 'cowgirls' in outpage.read_text(encoding="utf8")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -310,6 +310,7 @@ def test_toc_numbered(
         extension=f"{SPHINX_VERSION}.html",
     )
 
+
 def test_only(pages, cli):
     """Test {only} content is not built."""
     page = pages.joinpath("single_page.ipynb")
@@ -320,31 +321,47 @@ def test_only(pages, cli):
     assert html.joinpath("single_page.html").exists()
     outpage = html.joinpath("single_page.html")
     assert not html.joinpath("extra_page.html").exists()
-    assert 'slickers' not in outpage.read_text(encoding="utf8")
-    assert 'cowgirls' not in outpage.read_text(encoding="utf8")
+    assert "slickers" not in outpage.read_text(encoding="utf8")
+    assert "cowgirls" not in outpage.read_text(encoding="utf8")
+
 
 def test_only_tag(pages, cli):
     """Test tag cli builds {only} content."""
     page = pages.joinpath("single_page.ipynb")
     html = pages.joinpath("_build", "_page", "single_page", "html")
     index = html.joinpath("index.html")
-    result = cli.invoke(commands.build, [page.as_posix(), "-n", "-W", "--keep-going", "--tag", "cowboy"])
+    result = cli.invoke(
+        commands.build, [page.as_posix(), "-n", "-W", "--keep-going", "--tag", "cowboy"]
+    )
     assert result.exit_code == 0, result.output
     assert html.joinpath("single_page.html").exists()
     outpage = html.joinpath("single_page.html")
     assert not html.joinpath("extra_page.html").exists()
-    assert 'slickers' in outpage.read_text(encoding="utf8")
-    assert 'cowgirls' not in outpage.read_text(encoding="utf8")
+    assert "slickers" in outpage.read_text(encoding="utf8")
+    assert "cowgirls" not in outpage.read_text(encoding="utf8")
+
 
 def test_both_tags(pages, cli):
     """Test multiple tag creates boolean condition."""
     page = pages.joinpath("single_page.ipynb")
     html = pages.joinpath("_build", "_page", "single_page", "html")
     index = html.joinpath("index.html")
-    result = cli.invoke(commands.build, [page.as_posix(), "-n", "-W", "--keep-going", "--tag", "cowboy", "--tag", "cowgirl"])
+    result = cli.invoke(
+        commands.build,
+        [
+            page.as_posix(),
+            "-n",
+            "-W",
+            "--keep-going",
+            "--tag",
+            "cowboy",
+            "--tag",
+            "cowgirl",
+        ],
+    )
     assert result.exit_code == 0, result.output
     assert html.joinpath("single_page.html").exists()
     outpage = html.joinpath("single_page.html")
     assert not html.joinpath("extra_page.html").exists()
-    assert 'slickers' in outpage.read_text(encoding="utf8")
-    assert 'cowgirls' in outpage.read_text(encoding="utf8")
+    assert "slickers" in outpage.read_text(encoding="utf8")
+    assert "cowgirls" in outpage.read_text(encoding="utf8")


### PR DESCRIPTION
Simple addition to the cli to surface the sphinx "tag" command line option to build conditional content. Works like using `sphinx-build -t TAG <sourcedir>` with sphinx>=0.6 (see [sphinx documentation of the `open` directive](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-only).

This addresses issue #1290 (mistakenly refers to "open" directive). Possibly also #1425.

Multiple option allows for boolean TAG expression. For example

```jupyter-book build <sourcedir> --tag cowboy --tag cowgirl```

Is needed to build the following:
````
    ```{only} cowboy and cowgirl
     foo
    ```
````

