### PR TITLE
Remove unnecessary version constraint for click

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    click~=7.1
+    click>=7.1,<9
     docutils>=0.15,<0.18
     jsonschema<4
     # Include Jupytext to ensure users have the right version, even if not strictly necessary


### PR DESCRIPTION
As far as I can tell no click features are used that prevent an upgrade to v8 of click.

See executablebooks/jupyter-book#1590 for more info as to why this is necessary.

Related PR: https://github.com/executablebooks/sphinx-external-toc/pull/69