### PR TITLE
MAINT: Remove Python 3.6 and add Python 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.7", "3.8", "3.9"]
         sphinx: [">=3,<4", ">=4,<5"]
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,9 +14,10 @@ classifiers =
     License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Text Processing :: Markup
@@ -54,8 +55,7 @@ install_requires =
     sphinx_togglebutton
     sphinxcontrib-bibtex>=2.2.0,<=2.5.0
     sphinx-multitoc-numbering~=0.1.3
-    importlib_metadata;python_version < "3.7"
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 
 [options.entry_points]

--- a/tox.ini
+++ b/tox.ini
@@ -11,12 +11,12 @@
 # then then deleting compiled files has been found to fix it: `find . -name \*.pyc -delete`
 
 [tox]
-envlist = py37-sphinx3
+envlist = py39-sphinx3
 
 [testenv]
 usedevelop = true
 
-[testenv:py{36,37,38,39}-sphinx{3,4}]
+[testenv:py{37,38,39}-sphinx{3,4}]
 extras = testing
 deps =
     sphinx3: sphinx>=3,<4


### PR DESCRIPTION
This updates our tests + installation metadata to support pythons version 3.7/8/9

We also want to add 3.10 support, but leaving that to a follow-up PR to keep this one scoped to an easy turnaround.

ref: https://github.com/executablebooks/meta/issues/646