### PR TITLE
MAINT: Use Python 3.9 in github action for windows/osx

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -87,7 +87,7 @@ jobs:
       if: github.repository == 'executablebooks/jupyter-book'
       uses: codecov/codecov-action@v1
       with:
-        name: ebp-jupyter-book-pytests-py3.8
+        name: ebp-jupyter-book-pytests-py3.8  # Unclear if it needs to be 3.8 so leaving as-is even though we're running 3.9 now
         flags: pytests
         file: ./coverage.xml
         fail_ci_if_error: true
@@ -127,14 +127,14 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python-version }}
     - uses: actions/cache@v2
       with:
         path: ~\AppData\Local\pip\Cache
@@ -155,14 +155,14 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python-version }}
     - uses: actions/cache@v2
       with:
         path: ~\AppData\Local\pip\Cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -87,7 +87,7 @@ jobs:
       if: github.repository == 'executablebooks/jupyter-book'
       uses: codecov/codecov-action@v1
       with:
-        name: ebp-jupyter-book-pytests-py3.8  # Unclear if it needs to be 3.8 so leaving as-is even though we're running 3.9 now
+        name: ebp-jupyter-book-pytests-py3.8
         flags: pytests
         file: ./coverage.xml
         fail_ci_if_error: true
@@ -127,6 +127,8 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
+        # Using the default python in the Windows 2022 github actions runner
+        # ref: https://github.com/actions/virtual-environments/issues/4856
         python-version: [3.9]
 
     steps:


### PR DESCRIPTION
This updates the version of Python we use to test Jupyter Book in single-run jobs (AKA, in windows and OSX), now that the Windows 2022 runner ships with 3.9

ref: https://github.com/actions/virtual-environments/issues/4856