### PR TITLE
Add note about plotly and dollarmath incompatibility

### DIFF
--- a/docs/interactive/interactive.ipynb
+++ b/docs/interactive/interactive.ipynb
@@ -79,7 +79,12 @@
     "    html_js_files:\n",
     "    - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js\n",
     "```\n",
-    ":::\n"
+    ":::\n",
+    "\n",
+    "\n",
+    ":::{important}\n",
+    "Including plotly plots in a Jupyter Book page is [currently not compatible](https://github.com/executablebooks/jupyter-book/issues/1528) with the dollarmath syntax extension (mathematical notation written between two \"$\" characters). If you are trying to include both plotly plots and mathematical notation within the same page, and finding that plotly plots are not being rendered, this may be the cause. Try removing all use of the dollarmath syntax within the page and rebuilding the book.\n",
+    ":::"
    ]
   },
   {
@@ -206,7 +211,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -220,7 +225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/docs/interactive/interactive.ipynb
+++ b/docs/interactive/interactive.ipynb
@@ -211,7 +211,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -225,7 +225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds a short note to the page on interactive plotting to mention that plotly and dollarmath currently cannot be used on the same page as described in #1528.