### PR TITLE
PIN: Jinja < 3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "docutils>=0.15,<0.18",
     # TODO: Remove when we drop Sphinx 3 support. Jinja 3.1 breaks Sphinx 3 builds.
     # ref: https://github.com/executablebooks/jupyter-book/issues/1676
-    "jinja<3.1",
+    "Jinja2<3.1",
     "jsonschema<4",
     "linkify-it-py~=1.0.1",
     "myst-nb~=0.13.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ requires-python = ">=3.7"
 dependencies = [
     "click>=7.1,<9",
     "docutils>=0.15,<0.18",
+    # TODO: Remove when we drop Sphinx 3 support. Jinja 3.1 breaks Sphinx 3 builds.
+    # ref: https://github.com/executablebooks/jupyter-book/issues/1676
+    "jinja<3.1",
     "jsonschema<4",
     "linkify-it-py~=1.0.1",
     "myst-nb~=0.13.1",


### PR DESCRIPTION
This pins Jinja < 3.1, so that we don't run into the bug described in:

- https://github.com/executablebooks/jupyter-book/issues/1676

closes https://github.com/executablebooks/jupyter-book/issues/1676