### PR TITLE
fix(reference): add a missing ref

### DIFF
--- a/docs/content/references.md
+++ b/docs/content/references.md
@@ -87,7 +87,7 @@ Then, reference the figure by its `:name:` value. For example:
 | `` Here is [](my-fig-ref) ``               | Here is [](my-fig-ref)               |
 | `` Here is [My cool fig](my-fig-ref) `` | Here is [My cool fig](my-fig-ref)              |
 | `` Here is {numref}`my-fig-ref` ``            | Here is {numref}`my-fig-ref`            |
-| `` Here is {numref}`Custom Figure %s text ` `` | Here is {numref}`Custom Figure %s text <my-fig-ref>` |
+| `` Here is {numref}`Custom Figure %s text <my-fig-ref>` `` | Here is {numref}`Custom Figure %s text <my-fig-ref>` |
 
 (references:tables)=
 ## Reference tables


### PR DESCRIPTION
The tag `<my-fig-ref>` was missing from the custom label ref example.