### PR TITLE
MAINT: Fix broken autodoc link and latex test

### DIFF
--- a/docs/content/code-outputs.md
+++ b/docs/content/code-outputs.md
@@ -184,7 +184,11 @@ print("AB\x1b[43mCD\x1b[35mEF\x1b[1mGH\x1b[4mIJ\x1b[7m"
       "KL\x1b[49mMN\x1b[39mOP\x1b[22mQR\x1b[24mST\x1b[27mUV")
 ```
 
-This uses the built-in {py:class}`~myst-nb:myst_nb.ansi_lexer.AnsiColorLexer` [pygments lexer](https://pygments.org/).
+% NOTE: This used to be {py:class}`~myst-nb:myst_nb.ansi_lexer.AnsiColorLexer`%
+% but it started throwing Sphinx errors like:
+% /Users/runner/work/jupyter-book/jupyter-book/docs/content/code-outputs.md:187: WARNING: py:class reference target not found: myst-nb:myst_nb.ansi_lexer.AnsiColorLexer
+% so temporarily hard-coding the link until we figure out how to fix it.
+This uses the built-in [AnsiColorLexer](https://myst-nb.readthedocs.io/en/latest/api/index.html?highlight=colorlexer#myst_nb.core.lexers.AnsiColorLexer) [pygments lexer](https://pygments.org/).
 You can change the lexer used in the `_config.yml`, for example to turn off lexing:
 
 ```yaml

--- a/docs/content/code-outputs.md
+++ b/docs/content/code-outputs.md
@@ -184,11 +184,7 @@ print("AB\x1b[43mCD\x1b[35mEF\x1b[1mGH\x1b[4mIJ\x1b[7m"
       "KL\x1b[49mMN\x1b[39mOP\x1b[22mQR\x1b[24mST\x1b[27mUV")
 ```
 
-% NOTE: This used to be {py:class}`~myst-nb:myst_nb.ansi_lexer.AnsiColorLexer`%
-% but it started throwing Sphinx errors like:
-% /Users/runner/work/jupyter-book/jupyter-book/docs/content/code-outputs.md:187: WARNING: py:class reference target not found: myst-nb:myst_nb.ansi_lexer.AnsiColorLexer
-% so temporarily hard-coding the link until we figure out how to fix it.
-This uses the built-in [AnsiColorLexer](https://myst-nb.readthedocs.io/en/latest/api/index.html?highlight=colorlexer#myst_nb.core.lexers.AnsiColorLexer) [pygments lexer](https://pygments.org/).
+This uses the built-in {py:class}`~myst-nb:myst_nb.core.lexers.AnsiColorLexer` [pygments lexer](https://pygments.org/).
 You can change the lexer used in the `_config.yml`, for example to turn off lexing:
 
 ```yaml

--- a/tests/test_sphinx_jupyterbook_latex/test_toc.tex
+++ b/tests/test_sphinx_jupyterbook_latex/test_toc.tex
@@ -90,9 +90,6 @@ Chap 1 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.
 \sphinxAtStartPar
 Chap 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.
 
-\sphinxAtStartPar
-
-
 \sphinxAtStartPar{[}\hyperlink{cite.part1/chap2:id5}{CKS+10}, \hyperlink{cite.part1/chap2:id3}{HdHP+16}, \hyperlink{cite.part1/chap2:id2}{PGH11}, \hyperlink{cite.part1/chap2:id4}{SK14}{]}
 \begin{itemize}
 \item{} 


### PR DESCRIPTION
This adds a fix for [a random Sphinx error](https://github.com/executablebooks/jupyter-book/runs/6112159276?check_suite_focus=true#step:6:200) that started popping up in our docs, where it couldn't find the ColorLexer class in `myst-nb`. ~I spent 20 minutes trying to figure out how this role works and couldn't do it. So I'm hard-coding a fix and added a comment about it so we can follow up in the future.~ Ah I figured it out - the class got moved.

Will merge this quickly assuming that the tests are happy, so that we can get tests passing in all of the other open PRs as well and unblock them
