### PR TITLE
MAINT: Update default config copyright date to 2022

### DIFF
--- a/jupyter_book/default_config.yml
+++ b/jupyter_book/default_config.yml
@@ -7,7 +7,7 @@
 # Book settings
 title                       : My Jupyter Book  # The title of the book. Will be placed in the left navbar.
 author                      : The Jupyter Book community  # The author of the book
-copyright                   : "2021"  # Copyright year to be placed in the footer
+copyright                   : "2022"  # Copyright year to be placed in the footer
 logo                        : ""  # A path to the book logo
 # Patterns to skip when building the book. Can be glob-style (e.g. "*skip.ipynb")
 exclude_patterns            : [_build, Thumbs.db, .DS_Store, "**.ipynb_checkpoints"]


### PR DESCRIPTION
I like to start a project by copying the full default `_config.yml` file and customizing from there. This PR updates the default copyright date to `"2022"`.