### PR TITLE
FIX: fix mathjax macro syntax for sphinx>=4

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -70,8 +70,8 @@ sphinx:
     # mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
     # However, it is incompatible with the mathjax config below for macros
     mathjax3_config:
-      TeX:
-        Macros:
+      tex:
+        macros:
           "N": "\\mathbb{N}"
           "floor": ["\\lfloor#1\\rfloor", 1]
           "bmat": ["\\left[\\begin{array}"]

--- a/docs/advanced/sphinx.md
+++ b/docs/advanced/sphinx.md
@@ -239,8 +239,8 @@ You can add LaTeX macros for the whole book by defining them under the `Macros` 
 sphinx:
   config:
     mathjax_config:
-      TeX:
-        Macros:
+      tex:
+        macros:
           "N": "\\mathbb{N}"
           "floor": ["\\lfloor#1\\rfloor", 1]
           "bmat" : ["\\left[\\begin{array}"]


### PR DESCRIPTION
This should fix #1594 

