### PR TITLE
 MAINT: Fix reported issues from scheduled osx, and windows tests

### DIFF
--- a/docs/content/myst.md
+++ b/docs/content/myst.md
@@ -17,7 +17,7 @@ you'll write in the same flavour of **MyST Markdown**. Jupyter Book will know ho
 
 This page contains a few pieces of information about MyST Markdown and how it relates to Jupyter Book.
 You can find much more information about this flavour of Markdown at
-[the Myst Parser documentation](myst-parser:example_syntax).
+[the Myst Parser documentation](myst-parser:syntax/core).
 
 :::{admonition} Want to use RMarkdown directly?
 :class: tip


### PR DESCRIPTION
This PR fixes issues reported by the scheduled tests. 

However, the windows run appears to have issues resolving references due to document location:

The reported issue:

```
D:\a\jupyter-book\jupyter-book\CHANGELOG.md:22: WARNING: 'myst' reference target not found: ..\advanced\sphinx.md
```

corresponds to:

```md
- Allow recursively updating the sphinx configuration instead of totally over-writing it, see [the sphinx configuration docs](docs/advanced/sphinx.md) for details [#1599](https://github.com/executablebooks/jupyter-book/pull/1599) ([@kmpaul](https://github.com/kmpaul))
```

which looks like `sphinx` is removing `docs` and replacing it with a `..` on `windows` only. 

The directive:

````
```{include} ../../CHANGELOG.md
:relative-docs: docs/
:relative-images:
```
````

These options to `include` directive are added by [myst-parser](https://myst-parser.readthedocs.io/en/latest/develop/_changelog.html#id19) but looks like tests are passing in `myst-parser`