### PR TITLE
MAINT: Don't set the default language

### DIFF
--- a/jupyter_book/config.py
+++ b/jupyter_book/config.py
@@ -34,7 +34,6 @@ def get_default_sphinx_config():
             "sphinx_design",
             "sphinx_book_theme",
         ],
-        language=None,
         pygments_style="sphinx",
         html_theme="sphinx_book_theme",
         html_theme_options={"search_bar_text": "Search this book..."},

--- a/tests/test_config/test_config_sphinx_command.txt
+++ b/tests/test_config/test_config_sphinx_command.txt
@@ -23,7 +23,6 @@ html_theme_options = {'search_bar_text': 'Search this book...', 'launch_buttons'
 html_title = 'test'
 jupyter_cache = ''
 jupyter_execute_notebooks = 'auto'
-language = None
 latex_engine = 'pdflatex'
 myst_enable_extensions = ['colon_fence', 'dollarmath', 'linkify', 'substitution', 'tasklist']
 myst_url_schemes = ['mailto', 'http', 'https']

--- a/tests/test_config/test_config_sphinx_command_only_build_toc_files.txt
+++ b/tests/test_config/test_config_sphinx_command_only_build_toc_files.txt
@@ -23,7 +23,6 @@ html_theme_options = {'search_bar_text': 'Search this book...', 'launch_buttons'
 html_title = 'My Jupyter Book'
 jupyter_cache = ''
 jupyter_execute_notebooks = 'auto'
-language = None
 latex_engine = 'pdflatex'
 myst_enable_extensions = ['colon_fence', 'dollarmath', 'linkify', 'substitution', 'tasklist']
 myst_url_schemes = ['mailto', 'http', 'https']

--- a/tests/test_config/test_get_final_config_custom_myst_extensions.yml
+++ b/tests/test_config/test_get_final_config_custom_myst_extensions.yml
@@ -57,7 +57,6 @@ final:
   html_title: My Jupyter Book
   jupyter_cache: ''
   jupyter_execute_notebooks: auto
-  language: null
   latex_engine: pdflatex
   myst_enable_extensions:
   - colon_fence

--- a/tests/test_config/test_get_final_config_empty_.yml
+++ b/tests/test_config/test_get_final_config_empty_.yml
@@ -54,7 +54,6 @@ final:
   html_title: My Jupyter Book
   jupyter_cache: ''
   jupyter_execute_notebooks: auto
-  language: null
   latex_engine: pdflatex
   myst_enable_extensions:
   - colon_fence

--- a/tests/test_config/test_get_final_config_exclude_patterns_.yml
+++ b/tests/test_config/test_get_final_config_exclude_patterns_.yml
@@ -57,7 +57,6 @@ final:
   html_title: My Jupyter Book
   jupyter_cache: ''
   jupyter_execute_notebooks: auto
-  language: null
   latex_engine: pdflatex
   myst_enable_extensions:
   - colon_fence

--- a/tests/test_config/test_get_final_config_execute_method_.yml
+++ b/tests/test_config/test_get_final_config_execute_method_.yml
@@ -56,7 +56,6 @@ final:
   html_title: My Jupyter Book
   jupyter_cache: ''
   jupyter_execute_notebooks: cache
-  language: null
   latex_engine: pdflatex
   myst_enable_extensions:
   - colon_fence

--- a/tests/test_config/test_get_final_config_extended_syntax_.yml
+++ b/tests/test_config/test_get_final_config_extended_syntax_.yml
@@ -58,7 +58,6 @@ final:
   html_title: My Jupyter Book
   jupyter_cache: ''
   jupyter_execute_notebooks: auto
-  language: null
   latex_engine: pdflatex
   myst_enable_extensions:
   - linkify

--- a/tests/test_config/test_get_final_config_html_extra_footer_.yml
+++ b/tests/test_config/test_get_final_config_html_extra_footer_.yml
@@ -56,7 +56,6 @@ final:
   html_title: My Jupyter Book
   jupyter_cache: ''
   jupyter_execute_notebooks: auto
-  language: null
   latex_engine: pdflatex
   myst_enable_extensions:
   - colon_fence

--- a/tests/test_config/test_get_final_config_latex_doc_.yml
+++ b/tests/test_config/test_get_final_config_latex_doc_.yml
@@ -58,7 +58,6 @@ final:
   html_title: My Jupyter Book
   jupyter_cache: ''
   jupyter_execute_notebooks: auto
-  language: null
   latex_engine: pdflatex
   myst_enable_extensions:
   - colon_fence

--- a/tests/test_config/test_get_final_config_launch_buttons_.yml
+++ b/tests/test_config/test_get_final_config_launch_buttons_.yml
@@ -56,7 +56,6 @@ final:
   html_title: My Jupyter Book
   jupyter_cache: ''
   jupyter_execute_notebooks: auto
-  language: null
   latex_engine: pdflatex
   myst_enable_extensions:
   - colon_fence

--- a/tests/test_config/test_get_final_config_repository_.yml
+++ b/tests/test_config/test_get_final_config_repository_.yml
@@ -56,7 +56,6 @@ final:
   html_title: My Jupyter Book
   jupyter_cache: ''
   jupyter_execute_notebooks: auto
-  language: null
   latex_engine: pdflatex
   myst_enable_extensions:
   - colon_fence

--- a/tests/test_config/test_get_final_config_sphinx_default_.yml
+++ b/tests/test_config/test_get_final_config_sphinx_default_.yml
@@ -51,7 +51,6 @@ final:
   html_title: My Jupyter Book
   jupyter_cache: ''
   jupyter_execute_notebooks: auto
-  language: null
   latex_engine: pdflatex
   myst_enable_extensions:
   - colon_fence

--- a/tests/test_config/test_get_final_config_sphinx_recurse_.yml
+++ b/tests/test_config/test_get_final_config_sphinx_recurse_.yml
@@ -68,7 +68,6 @@ final:
   html_title: My Jupyter Book
   jupyter_cache: ''
   jupyter_execute_notebooks: auto
-  language: null
   latex_engine: pdflatex
   myst_enable_extensions:
   - colon_fence

--- a/tests/test_config/test_get_final_config_title_.yml
+++ b/tests/test_config/test_get_final_config_title_.yml
@@ -55,7 +55,6 @@ final:
   html_title: hallo
   jupyter_cache: ''
   jupyter_execute_notebooks: auto
-  language: null
   latex_engine: pdflatex
   myst_enable_extensions:
   - colon_fence

--- a/tests/test_config/test_mathjax_config_warning.sphinx4.yml
+++ b/tests/test_config/test_mathjax_config_warning.sphinx4.yml
@@ -60,7 +60,6 @@ final:
   html_title: My Jupyter Book
   jupyter_cache: ''
   jupyter_execute_notebooks: auto
-  language: null
   latex_engine: pdflatex
   mathjax3_config:
     TeX:

--- a/tests/test_config/test_mathjax_config_warning_mathjax2path.sphinx4.yml
+++ b/tests/test_config/test_mathjax_config_warning_mathjax2path.sphinx4.yml
@@ -61,7 +61,6 @@ final:
   html_title: My Jupyter Book
   jupyter_cache: ''
   jupyter_execute_notebooks: auto
-  language: null
   latex_engine: pdflatex
   mathjax2_config:
     TeX:


### PR DESCRIPTION
For Sphinx 5 compatibility.

See [release notes](https://www.sphinx-doc.org/en/master/changes.html#id15) and https://github.com/sphinx-doc/sphinx/issues/10474.

Related #1749 and https://github.com/executablebooks/meta/issues/750

----------

I know that the CI pipeline isn't running with Sphinx 5 yet, but I tested this locally by forcing a `pip install "sphinx==5.0.1"` and making this one-line change in the `jupyter-book` source.
With that my dissertation project built successfully.