### PR TITLE
📖  DOCS: Use YAML in front-matter

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,5 +1,5 @@
 ---
-:title: Books with Jupyter
+title: Books with Jupyter
 ---
 
 ::::{grid} 2


### PR DESCRIPTION
I think this title block should be YAML:
https://myst-parser.readthedocs.io/en/latest/syntax/syntax.html?highlight=front#front-matter

Haven't tested if this would actually add a title though?

If this is not a typo, curious what it does!