### PR TITLE
FIX: Enable maths in singlehtml mode

### DIFF
--- a/jupyter_book/sphinx.py
+++ b/jupyter_book/sphinx.py
@@ -140,6 +140,10 @@ def build_sphinx(
             )
             app.config.latex_documents = new_latex_documents
 
+            # set the below flag to always to enable maths in singlehtml builder
+            if app.builder.name == "singlehtml":
+                app.set_html_assets_policy("always")            
+            
             # setting up sphinx-multitoc-numbering
             if app.config["use_multitoc_numbering"]:
                 # if sphinx-external-toc is used

--- a/jupyter_book/sphinx.py
+++ b/jupyter_book/sphinx.py
@@ -142,8 +142,8 @@ def build_sphinx(
 
             # set the below flag to always to enable maths in singlehtml builder
             if app.builder.name == "singlehtml":
-                app.set_html_assets_policy("always")            
-            
+                app.set_html_assets_policy("always")
+
             # setting up sphinx-multitoc-numbering
             if app.config["use_multitoc_numbering"]:
                 # if sphinx-external-toc is used


### PR DESCRIPTION
Setting the html_assets_policy flag  to always includes mathjax in singlehtml builder. This also helps in maths rendering for pdfhtml builder. This flag is defaulted to per_page inside sphinx codebase, which leads to excluding mathjax for singlehtml builder.

Resolves #1705 