### PR TITLE
DOCS: remove *-recommended libs for latex

### DIFF
--- a/docs/advanced/pdf.md
+++ b/docs/advanced/pdf.md
@@ -131,8 +131,8 @@ latex:
 For `Debian`-based `Linux` platforms it is recommended to install the following packages:
 
 ```bash
-sudo apt-get install texlive-latex-recommended texlive-latex-extra \
-                     texlive-fonts-recommended texlive-fonts-extra \
+sudo apt-get install texlive-latex-extra \
+                     texlive-fonts-extra \
                      texlive-xetex latexmk
 ```
 


### PR DESCRIPTION
remove `texlive-latex-recommended` & `texlive-fonts-recommended` from `Installation and Setup` because has no effect and book builded