### PR TITLE
DOCS: Replace ::: by ``` in admonition example

### DIFF
--- a/docs/content/components.md
+++ b/docs/content/components.md
@@ -212,10 +212,10 @@ own titles and stylings. For example:
 
 ````{example}
 
-:::{admonition} Click here!
+```{admonition} Click here!
 :class: tip, dropdown
 Here's what's inside!
-:::
+```
 
 ````
 


### PR DESCRIPTION
To stay coherent with other examples written in markdown.