### PR TITLE
Future Warning

### DIFF
--- a/examples/single_page.ipynb
+++ b/examples/single_page.ipynb
@@ -66,7 +66,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.util.testing.makeDataFrame()\n",
+    "#df = pd.util.testing.makeDataFrame()\n",
+    "df = pd.testing.makeDataFrame()\n",
     "df.plot.scatter(\"A\", \"B\")"
    ]
   },


### PR DESCRIPTION
FutureWarning: pandas.util.testing is deprecated. Use the functions in the public API at pandas.testing instead.
  import pandas.util.testing
But:
Warning: module 'pandas.testing' has no attribute 'makeDataFrame'

maybe this could be
from pandas import DataFrame
df = pd.DataFrame()
