### PR TITLE
DOCS: Add documentation on enabling Plausible Analytics

### DIFF
--- a/docs/advanced/html.md
+++ b/docs/advanced/html.md
@@ -134,7 +134,7 @@ script.dataset.domain = "YOUR-DATA-DOMAIN";
 document.getElementsByTagName('head')[0].appendChild(script);
 ```
 
-This should inject the approrpiate code into the <head> via javascript, and you will be able to get analytics on your website through either the commercial company-hosted dashboard, or a [self-hosted instance](https://plausible.io/docs/self-hosting).
+This should inject the approrpiate code into the `<head>` via javascript, and you will be able to get analytics on your website through either the commercial company-hosted dashboard, or a [self-hosted instance](https://plausible.io/docs/self-hosting).
 
 
 (html:link-check)=

--- a/docs/advanced/html.md
+++ b/docs/advanced/html.md
@@ -105,8 +105,36 @@ html:
 
 :::{seealso}
 - For more about Google Analytics, see [the Google Analytics documentation](https://analytics.google.com/analytics/web/) for more information.
-- To use **other analytics services**, like [Plausible analytics](https://plausible.io/), you should link the relevant libraries via the instructions in [](custom-assets).
 :::
+
+
+## Use Plausible Analytics
+
+[Plausible Analytics](https://plausible.io) is a lightweight, open source, [privacy-focused](https://plausible.io/privacy-focused-web-analytics) analytics service that can be used as a more ethical alternative (or, in addition to) to Google Analytics.
+The requirement to use Plausible.io is to add a snippet into the `<head>` section of every html page:
+
+```
+<script defer data-domain="YOUR-DATA-DOMAIN" src="https://plausible.io/js/plausible.js"></script>
+```
+
+It is not yet possible in JupyterBook to directly inject `html` code into the site `<head>`, but it is possible to add [](custom-assets).
+te
+To use Plausible Analytics in your JupyterBook, simply add this code into an arbitrarily named `.js` file in the `_static` directory (create the directory in the root of your book if it does not already exist):
+
+```
+var script = document.createElement('script');
+script.defer = true;
+script.src = "https://plausible.io/js/script.js";
+script.dataset.domain = "YOUR-DATA-DOMAIN";
+
+// optional if using proxy, see Plausible.io documentation for more about this
+// script.dataset.api = 'https://yourproxy.com/api/event';
+
+document.getElementsByTagName('head')[0].appendChild(script);
+```
+
+This should inject the approrpiate code into the <head> via javascript, and you will be able to get analytics on your website through either the commercial company-hosted dashboard, or a [self-hosted instance](https://plausible.io/docs/self-hosting).
+
 
 (html:link-check)=
 ## Check external links in your book

--- a/docs/advanced/html.md
+++ b/docs/advanced/html.md
@@ -134,7 +134,7 @@ script.dataset.domain = "YOUR-DATA-DOMAIN";
 document.getElementsByTagName('head')[0].appendChild(script);
 ```
 
-This should inject the approrpiate code into the `<head>` via javascript, and you will be able to get analytics on your website through either the commercial company-hosted dashboard, or a [self-hosted instance](https://plausible.io/docs/self-hosting).
+This should inject the appropriate code into the `<head>` via javascript, and you will be able to get analytics on your website through either the commercial company-hosted dashboard, or a [self-hosted instance](https://plausible.io/docs/self-hosting).
 
 
 (html:link-check)=

--- a/docs/advanced/html.md
+++ b/docs/advanced/html.md
@@ -120,7 +120,7 @@ The requirement to use Plausible.io is to add a snippet into the `<head>` sectio
 % TODO: When we update our dependency to PyData 0.10 there will be native support for Plausible
 % ref: https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/analytics.html#plausible-analytics
 It is not yet possible in JupyterBook to directly inject `html` code into the site `<head>`, but it is possible to add [](custom-assets).
-To use Plausible Analytics in your JupyterBook, simply add this code into an arbitrarily named `.js` file in the `_static` directory (create the directory in the root of your book if it does not already exist):
+To use Plausible Analytics in your JupyterBook, add this code into an arbitrarily-named `.js` file in the `_static` directory (create the directory in the root of your book if it does not already exist):
 
 ```
 var script = document.createElement('script');

--- a/docs/advanced/html.md
+++ b/docs/advanced/html.md
@@ -117,6 +117,8 @@ The requirement to use Plausible.io is to add a snippet into the `<head>` sectio
 <script defer data-domain="YOUR-DATA-DOMAIN" src="https://plausible.io/js/plausible.js"></script>
 ```
 
+% TODO: When we update our dependency to PyData 0.10 there will be native support for Plausible
+% ref: https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/analytics.html#plausible-analytics
 It is not yet possible in JupyterBook to directly inject `html` code into the site `<head>`, but it is possible to add [](custom-assets).
 te
 To use Plausible Analytics in your JupyterBook, simply add this code into an arbitrarily named `.js` file in the `_static` directory (create the directory in the root of your book if it does not already exist):

--- a/docs/advanced/html.md
+++ b/docs/advanced/html.md
@@ -122,7 +122,7 @@ The requirement to use Plausible.io is to add a snippet into the `<head>` sectio
 It is not yet possible in JupyterBook to directly inject `html` code into the site `<head>`, but it is possible to add [](custom-assets).
 To use Plausible Analytics in your JupyterBook, add this code into an arbitrarily-named `.js` file in the `_static` directory (create the directory in the root of your book if it does not already exist):
 
-```
+```javascript
 var script = document.createElement('script');
 script.defer = true;
 script.src = "https://plausible.io/js/script.js";

--- a/docs/advanced/html.md
+++ b/docs/advanced/html.md
@@ -120,7 +120,6 @@ The requirement to use Plausible.io is to add a snippet into the `<head>` sectio
 % TODO: When we update our dependency to PyData 0.10 there will be native support for Plausible
 % ref: https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/analytics.html#plausible-analytics
 It is not yet possible in JupyterBook to directly inject `html` code into the site `<head>`, but it is possible to add [](custom-assets).
-te
 To use Plausible Analytics in your JupyterBook, simply add this code into an arbitrarily named `.js` file in the `_static` directory (create the directory in the root of your book if it does not already exist):
 
 ```


### PR DESCRIPTION
Hello,

I wanted to add a section in the documentation about enabling and adding Plausible.io since I've now got its working.

Let me know if you'd suggest any changes to what I've written. (h/t to [@RobertJoonas](https://github.com/plausible/analytics/discussions/2117#discussioncomment-3420303) for the code and the idea).

Fixes and closes #1811.