### PR TITLE
unpin myst-nb

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "Jinja2",
     "jsonschema<4",
     "linkify-it-py~=1.0.1",
-    "myst-nb~=0.13.1",
+    "myst-nb",
     "pyyaml",
     "sphinx>=4,<5",
     "sphinx-comments",


### PR DESCRIPTION
@chrisjsewell has made substantial improvements to myst-nb, which is now at 0.16, whereas within jb it is still pinned at 0.13

I'm using myst-nb 0.16 in my jb-fork  already for 2 months and it runs smooth. I specifically like the consistent numbering of the figure captions (both from md and code cell outputs) by adding tags to the code cell outputs.

It might be that pinning of myst-nb is done in order to prepare for sphinx 5. But I would no longer hold it at 0.13 for this reason only.