### PR TITLE
DOCS: Add an example of admonition with warning style

### DIFF
--- a/docs/reference/cheatsheet.md
+++ b/docs/reference/cheatsheet.md
@@ -560,6 +560,22 @@ must also include a table title. See example above.
   - ```{important} This is an example
     of an important directive.
     ```
+* - ````md
+    ```{admonition} Title
+    :class: warning
+    text
+    ```
+    ````
+  - ````md
+    ```{admonition} This is a title
+    :class: warning
+    An example of an admonition with a title and a warning style.
+    ```
+    ````
+  - ```{admonition} This is a title
+    :class: warning
+    An example of an admonition with a title and a warning style.
+    ```
 ``````
 
 ## Figures and images


### PR DESCRIPTION
I didn't find this useful tip (change the class of an admonition) in the documentation. See https://jupyterbook.org/en/stable/interactive/hiding.html?highlight=admonition#toggle-admonition-content-with-dropdowns and https://jupyterbook.org/en/stable/advanced/html.html?highlight=admonition#an-example-custom-admonitions for related but different things.