### PR TITLE
DOCS: Remove incomplete documentation section on adding metadata

### DIFF
--- a/docs/content/metadata.md
+++ b/docs/content/metadata.md
@@ -102,7 +102,3 @@ for ipath in notebooks:
 
     nbf.write(ntbk, ipath)
 ```
-
-## Add metadata to notebook cells
-
-Stuff about tags etc


### PR DESCRIPTION
Looks like this was left inadvertently.