### PR TITLE
Remove leading $ from console command

### DIFF
--- a/docs/start/create.md
+++ b/docs/start/create.md
@@ -8,7 +8,7 @@ Jupyter Book comes bundled with a lightweight sample book to help you understand
 Create a sample book by running the following command:
 
 ```console
-$ jupyter-book create mynewbook/
+jupyter-book create mynewbook/
 ```
 
 This will generate a mini Jupyter Book that you can both build and explore locally. It will have a few decisions made for you, and you can explore the configuration of the book in `_config.yml` and its structure in `_toc.yml`. Use this book as inspiration, or as a starting point to work from.


### PR DESCRIPTION
This allows to run the command as copied