### PR TITLE
DOCS: Add copybutton console prefix

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -59,29 +59,12 @@ latex:
 
 sphinx:
   config:
-    nb_custom_formats:
-      .Rmd:
-        - jupytext.reads
-        - fmt: Rmd
     bibtex_reference_style: author_year  # or label, super, \supercite
+    copybutton_prompt_text: "$"
     execution_show_tb: True
     execution_timeout: 120
-    # TODO: #917 this path will be the default in sphinx v4
-    # mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
-    # However, it is incompatible with the mathjax config below for macros
-    mathjax3_config:
-      tex:
-        macros:
-          "N": "\\mathbb{N}"
-          "floor": ["\\lfloor#1\\rfloor", 1]
-          "bmat": ["\\left[\\begin{array}"]
-          "emat": ["\\end{array}\\right]"]
-    latex_elements:
-        preamble: |
-          \newcommand\N{\mathbb{N}}
-          \newcommand\floor[1]{\lfloor#1\rfloor}
-          \newcommand{\bmat}{\left[\begin{array}}
-          \newcommand{\emat}{\end{array}\right]}
+    html_extra_path:
+      - images/badge.svg
     intersphinx_mapping:
       ebp:
         - "https://executablebooks.org/en/latest/"
@@ -101,6 +84,27 @@ sphinx:
       sd:
         - https://sphinx-design.readthedocs.io/en/latest
         - null
+    language: en
+    latex_elements:
+        preamble: |
+          \newcommand\N{\mathbb{N}}
+          \newcommand\floor[1]{\lfloor#1\rfloor}
+          \newcommand{\bmat}{\left[\begin{array}}
+          \newcommand{\emat}{\end{array}\right]}
+    # TODO: #917 this path will be the default in sphinx v4
+    # mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+    # However, it is incompatible with the mathjax config below for macros
+    mathjax3_config:
+      tex:
+        macros:
+          "N": "\\mathbb{N}"
+          "floor": ["\\lfloor#1\\rfloor", 1]
+          "bmat": ["\\left[\\begin{array}"]
+          "emat": ["\\end{array}\\right]"]
+    nb_custom_formats:
+      .Rmd:
+        - jupytext.reads
+        - fmt: Rmd
     rediraffe_branch: 'master'
     rediraffe_redirects:
       content-types/index.md: file-types/index.md
@@ -110,9 +114,6 @@ sphinx:
       content-types/jupytext.md: file-types/jupytext.Rmd
       content-types/restructuredtext.md: file-types/restructuredtext.md
       customize/toc.md: structure/toc.md
-    language: en
-    html_extra_path:
-      - images/badge.svg
 
 
   extra_extensions:


### PR DESCRIPTION
This adds the sphinx copybutton prefix configuration so that console code snippets with a leading `$` won't include the `$` in the copied text.

- closes https://github.com/executablebooks/jupyter-book/pull/1860 by superceding it

This also sorts our `config` section to be alphabetical