### PR TITLE
MAINT: Move pypi publish to dedicated workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+# This will run every time a tag is created and pushed to the repository.
+# It calls our tests workflow via a `workflow_call`, and if tests pass
+# then it triggers our upload to PyPI for a new release.
+name: Publish to PyPI
+on:
+  release:
+    types: ["published"]
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml
+  publish:
+    name: publish
+    needs: [tests] # require tests to pass before deploy runs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Install flit
+        run: |
+          pip install flit~=3.6
+
+      - name: Build and publish
+        run: |
+          flit publish
+        env:
+          FLIT_USERNAME: __token__
+          FLIT_PASSWORD: ${{ secrets.PYPI_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
     tags:
       - 'v*'
   pull_request:
+  workflow_call:
 
 env:
   # Force colors for logs
@@ -109,27 +110,3 @@ jobs:
 
     - name: Run pytest
       run: pytest --durations=10 -m 'not requires_tex'
-
-  publish:
-
-    name: Publish to PyPi
-    needs: [pre-commit, test-with-cov, tests]
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v3
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-      - name: Install flit
-        run: |
-          pip install flit~=3.6
-
-      - name: Build and publish
-        run: |
-          flit publish
-        env:
-          FLIT_USERNAME: __token__
-          FLIT_PASSWORD: ${{ secrets.PYPI_KEY }}


### PR DESCRIPTION
Currently we have a workflow embedded in `tests.yml` that is called only if a new release is made. However this shows us as "not run" in our test suite in github and messes with the passing tests condition.

This PR factors that out into a dedicated workflow file that is run on `publish` and _calls_ our test suite before running the publish command. That should mean the "Publish to PyPI" action never gets run unless we are publishing.