### PR TITLE
maint: remove precautionary upper version bounds on some dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,24 +28,28 @@ keywords = [
 dynamic = ["description", "version"]
 requires-python = ">=3.7"
 dependencies = [
-    "click>=7.1,<9",
+    "click>=7.1",
+    # FIXME: remove upper bound on docutils or describe why its constrainted to
+    #        0.18.x
     "docutils>=0.15,<0.18",
-    "Jinja2",
-    "jsonschema<5",
-    "linkify-it-py~=2.0.0",
+    "jsonschema",
+    "linkify-it-py>=2",
     "myst-nb~=0.13.1",
-    "pyyaml",
+    # FIXME: remove upper bound on sphinx or describe why its constrainted to 4
     "sphinx>=4,<5",
-    "sphinx-comments",
-    "sphinx-copybutton",
+    # FIXME: remove upper bound on sphinx-external-toc or describe why its
+    #        constrainted to 0.2.x
     "sphinx-external-toc~=0.2.3",
+    # FIXME: remove upper bound on sphinx-jupyterbook-latex or describe why its
+    #        constrainted to 0.4.x
     "sphinx-jupyterbook-latex~=0.4.6",
+    # FIXME: remove upper bound on sphinx-design or describe why its
+    #        constrainted to 0.1.x
     "sphinx-design~=0.1.0",
-    "sphinx-thebe~=0.1.1",
-    "sphinx_book_theme~=0.3.2",
-    "sphinx_togglebutton",
-    "sphinxcontrib-bibtex>=2.2.0,<=2.5.0",
-    "sphinx-multitoc-numbering~=0.1.3",
+    "sphinx-thebe>=0.1.1",
+    "sphinx_book_theme>=0.3.2",
+    "sphinxcontrib-bibtex>=2.2.0",
+    "sphinx-multitoc-numbering>=0.1.3",
 ]
 
 [project.license]


### PR DESCRIPTION
For all dependencies with a version upper bound that is clearly precautionary, where the upper bound is not constraining the version currently, this PR removes the upper bound. For all remaining upper bounds, a fixme note is added about trying to sway away from precautionary upper version bounds of dependencies.

The idea is to switch away from having precautionary upper bounds of the versions in python package dependencies. My motivation for doing so is:
1. its a common practice in the python ecosystem
2. there is no automation or similar to ensure that the versions are bumped regularly currently, so the reason the upper bound gets bumped is mainly that users run into issues that they debug stem from the upper bound in this package

This is a step towards resolving an issue, #1898, but just a step as I've not unpinned myst-nb and some other dependencies where the upper bound makes a clear difference.

The tests are failing here, [and in the main branch](https://github.com/executablebooks/jupyter-book/actions) it seems. I think this PR should have no impact at all though, as they upper bounds removed in this PR were just
