### PR TITLE
MAINT: Remove `cell_metadata_filter: -all` from template

### DIFF
--- a/jupyter_book/book_template/markdown-notebooks.md
+++ b/jupyter_book/book_template/markdown-notebooks.md
@@ -1,6 +1,5 @@
 ---
 jupytext:
-  cell_metadata_filter: -all
   formats: md:myst
   text_representation:
     extension: .md


### PR DESCRIPTION
Before this merge, `jupyter-book create mynewbook/` generates an example MyST notebook with following preamble:
```
---
jupytext:
  cell_metadata_filter: -all
  formats: md:myst
  text_representation:
    extension: .md
    format_name: myst
    format_version: 0.13
    jupytext_version: 1.11.5
kernelspec:
  display_name: Python 3
  language: python
  name: python3
---
```

This PR removes the line `cell_metadata_filter: -all`.

It seems extraneous, and causes unexpected behavior, especially for new users of `jupyter-book`, who are likely to use this file as the copy-and-paste basis for all of their MyST markdown notebooks. If they do so, they will find that when they use `jupytext` to sync between MyST and other representations of the notebook (e.g. ipynb for WYSIWYG editing), all cell metadata, including tags, are dropped when syncing. See for example the confusion here: https://github.com/mwouts/jupytext/issues/1024