### PR TITLE
Fix test for cookiecutter

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -166,7 +166,7 @@ Explore this book {fas}`arrow-right`
 
 **The Turing Way**
 ^^^
-```{image} https://the-turing-way.netlify.app/_static/logo.jpg
+```{image} https://the-turing-way.netlify.app/_static/logo-detail-with-text.svg
 :height: 100
 ```
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -34,7 +34,7 @@ def test_create_from_cookiecutter(temp_with_override: Path, cli):
     assert book.joinpath("my_book", "my_book", "_config.yml").exists()
     assert len(list(book.joinpath("my_book").iterdir())) == 7
     assert len(list(book.joinpath("my_book", ".github", "workflows").iterdir())) == 1
-    assert len(list(book.joinpath("my_book", "my_book").iterdir())) == 8
+    assert len(list(book.joinpath("my_book", "my_book").iterdir())) == 9
 
 
 def test_build_from_template(temp_with_override, cli):


### PR DESCRIPTION
This is a quick fix to get a test passing - it looks like there's an extra file that got added that we didn't update a test for. Here's the list that is created, it all seems reasonable to me so I'm gonna merge this quickly if tests pass so that tests on `main` can be happy.

```
my_book/markdown.md
my_book/references.bib
my_book/_config.yml
my_book/notebooks.ipynb
my_book/content.md
my_book/markdown-notebooks.md
my_book/_toc.yml
my_book/logo.png
my_book/intro.md
```