### PR TITLE
Change default for launch_buttons.binderhub_url to "" (thus no launch buttons)

### DIFF
--- a/jupyter_book/default_config.yml
+++ b/jupyter_book/default_config.yml
@@ -72,7 +72,7 @@ latex:
 # Launch button settings
 launch_buttons:
   notebook_interface        : classic  # The interface interactive links will activate ["classic", "jupyterlab"]
-  binderhub_url             : https://mybinder.org  # The URL of the BinderHub (e.g., https://mybinder.org)
+  binderhub_url             : ""  # The URL of the BinderHub (e.g., https://mybinder.org)
   jupyterhub_url            : ""  # The URL of the JupyterHub (e.g., https://datahub.berkeley.edu)
   thebe                     : false  # Add a thebe button to pages (requires the repository to run on Binder)
   colab_url                 : "" # The URL of Google Colab (https://colab.research.google.com)

--- a/tests/test_config/test_config_sphinx_command.txt
+++ b/tests/test_config/test_config_sphinx_command.txt
@@ -19,7 +19,7 @@ html_favicon = ''
 html_logo = ''
 html_sourcelink_suffix = ''
 html_theme = 'sphinx_book_theme'
-html_theme_options = {'search_bar_text': 'Search this book...', 'launch_buttons': {'notebook_interface': 'classic', 'binderhub_url': 'https://mybinder.org', 'jupyterhub_url': '', 'thebe': False, 'colab_url': ''}, 'path_to_docs': '', 'repository_url': 'https://github.com/executablebooks/jupyter-book', 'repository_branch': 'master', 'google_analytics_id': '', 'extra_navbar': 'Powered by <a href="https://jupyterbook.org">Jupyter Book</a>', 'extra_footer': '', 'home_page_in_toc': True, 'announcement': '', 'use_repository_button': False, 'use_edit_page_button': False, 'use_issues_button': False}
+html_theme_options = {'search_bar_text': 'Search this book...', 'launch_buttons': {'notebook_interface': 'classic', 'binderhub_url': '', 'jupyterhub_url': '', 'thebe': False, 'colab_url': ''}, 'path_to_docs': '', 'repository_url': 'https://github.com/executablebooks/jupyter-book', 'repository_branch': 'master', 'google_analytics_id': '', 'extra_navbar': 'Powered by <a href="https://jupyterbook.org">Jupyter Book</a>', 'extra_footer': '', 'home_page_in_toc': True, 'announcement': '', 'use_repository_button': False, 'use_edit_page_button': False, 'use_issues_button': False}
 html_title = 'test'
 jupyter_cache = ''
 jupyter_execute_notebooks = 'auto'

--- a/tests/test_config/test_config_sphinx_command_only_build_toc_files.txt
+++ b/tests/test_config/test_config_sphinx_command_only_build_toc_files.txt
@@ -19,7 +19,7 @@ html_favicon = ''
 html_logo = ''
 html_sourcelink_suffix = ''
 html_theme = 'sphinx_book_theme'
-html_theme_options = {'search_bar_text': 'Search this book...', 'launch_buttons': {'notebook_interface': 'classic', 'binderhub_url': 'https://mybinder.org', 'jupyterhub_url': '', 'thebe': False, 'colab_url': ''}, 'path_to_docs': '', 'repository_url': 'https://github.com/executablebooks/jupyter-book', 'repository_branch': 'master', 'google_analytics_id': '', 'extra_navbar': 'Powered by <a href="https://jupyterbook.org">Jupyter Book</a>', 'extra_footer': '', 'home_page_in_toc': True, 'announcement': '', 'use_repository_button': False, 'use_edit_page_button': False, 'use_issues_button': False}
+html_theme_options = {'search_bar_text': 'Search this book...', 'launch_buttons': {'notebook_interface': 'classic', 'binderhub_url': '', 'jupyterhub_url': '', 'thebe': False, 'colab_url': ''}, 'path_to_docs': '', 'repository_url': 'https://github.com/executablebooks/jupyter-book', 'repository_branch': 'master', 'google_analytics_id': '', 'extra_navbar': 'Powered by <a href="https://jupyterbook.org">Jupyter Book</a>', 'extra_footer': '', 'home_page_in_toc': True, 'announcement': '', 'use_repository_button': False, 'use_edit_page_button': False, 'use_issues_button': False}
 html_title = 'My Jupyter Book'
 jupyter_cache = ''
 jupyter_execute_notebooks = 'auto'

--- a/tests/test_config/test_get_final_config_custom_myst_extensions.yml
+++ b/tests/test_config/test_get_final_config_custom_myst_extensions.yml
@@ -42,7 +42,7 @@ final:
     google_analytics_id: ''
     home_page_in_toc: true
     launch_buttons:
-      binderhub_url: https://mybinder.org
+      binderhub_url: ''
       colab_url: ''
       jupyterhub_url: ''
       notebook_interface: classic

--- a/tests/test_config/test_get_final_config_empty_.yml
+++ b/tests/test_config/test_get_final_config_empty_.yml
@@ -39,7 +39,7 @@ final:
     google_analytics_id: ''
     home_page_in_toc: true
     launch_buttons:
-      binderhub_url: https://mybinder.org
+      binderhub_url: ''
       colab_url: ''
       jupyterhub_url: ''
       notebook_interface: classic

--- a/tests/test_config/test_get_final_config_exclude_patterns_.yml
+++ b/tests/test_config/test_get_final_config_exclude_patterns_.yml
@@ -42,7 +42,7 @@ final:
     google_analytics_id: ''
     home_page_in_toc: true
     launch_buttons:
-      binderhub_url: https://mybinder.org
+      binderhub_url: ''
       colab_url: ''
       jupyterhub_url: ''
       notebook_interface: classic

--- a/tests/test_config/test_get_final_config_execute_method_.yml
+++ b/tests/test_config/test_get_final_config_execute_method_.yml
@@ -41,7 +41,7 @@ final:
     google_analytics_id: ''
     home_page_in_toc: true
     launch_buttons:
-      binderhub_url: https://mybinder.org
+      binderhub_url: ''
       colab_url: ''
       jupyterhub_url: ''
       notebook_interface: classic

--- a/tests/test_config/test_get_final_config_extended_syntax_.yml
+++ b/tests/test_config/test_get_final_config_extended_syntax_.yml
@@ -43,7 +43,7 @@ final:
     google_analytics_id: ''
     home_page_in_toc: true
     launch_buttons:
-      binderhub_url: https://mybinder.org
+      binderhub_url: ''
       colab_url: ''
       jupyterhub_url: ''
       notebook_interface: classic

--- a/tests/test_config/test_get_final_config_html_extra_footer_.yml
+++ b/tests/test_config/test_get_final_config_html_extra_footer_.yml
@@ -41,7 +41,7 @@ final:
     google_analytics_id: ''
     home_page_in_toc: true
     launch_buttons:
-      binderhub_url: https://mybinder.org
+      binderhub_url: ''
       colab_url: ''
       jupyterhub_url: ''
       notebook_interface: classic

--- a/tests/test_config/test_get_final_config_latex_doc_.yml
+++ b/tests/test_config/test_get_final_config_latex_doc_.yml
@@ -43,7 +43,7 @@ final:
     google_analytics_id: ''
     home_page_in_toc: true
     launch_buttons:
-      binderhub_url: https://mybinder.org
+      binderhub_url: ''
       colab_url: ''
       jupyterhub_url: ''
       notebook_interface: classic

--- a/tests/test_config/test_get_final_config_repository_.yml
+++ b/tests/test_config/test_get_final_config_repository_.yml
@@ -41,7 +41,7 @@ final:
     google_analytics_id: ''
     home_page_in_toc: true
     launch_buttons:
-      binderhub_url: https://mybinder.org
+      binderhub_url: ''
       colab_url: ''
       jupyterhub_url: ''
       notebook_interface: classic

--- a/tests/test_config/test_get_final_config_title_.yml
+++ b/tests/test_config/test_get_final_config_title_.yml
@@ -40,7 +40,7 @@ final:
     google_analytics_id: ''
     home_page_in_toc: true
     launch_buttons:
-      binderhub_url: https://mybinder.org
+      binderhub_url: ''
       colab_url: ''
       jupyterhub_url: ''
       notebook_interface: classic

--- a/tests/test_config/test_mathjax_config_warning.sphinx4.yml
+++ b/tests/test_config/test_mathjax_config_warning.sphinx4.yml
@@ -45,7 +45,7 @@ final:
     google_analytics_id: ''
     home_page_in_toc: true
     launch_buttons:
-      binderhub_url: https://mybinder.org
+      binderhub_url: ''
       colab_url: ''
       jupyterhub_url: ''
       notebook_interface: classic

--- a/tests/test_config/test_mathjax_config_warning_mathjax2path.sphinx4.yml
+++ b/tests/test_config/test_mathjax_config_warning_mathjax2path.sphinx4.yml
@@ -46,7 +46,7 @@ final:
     google_analytics_id: ''
     home_page_in_toc: true
     launch_buttons:
-      binderhub_url: https://mybinder.org
+      binderhub_url: ''
       colab_url: ''
       jupyterhub_url: ''
       notebook_interface: classic


### PR DESCRIPTION
Fixes https://github.com/executablebooks/jupyter-book/issues/1463

See https://github.com/executablebooks/jupyter-book/issues/1463#issuecomment-1445131176

I guess this change should be documented somewhere. But where?