### PR TITLE
Add `html_last_updated_fmt` to default template

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -71,7 +71,6 @@ sphinx:
     suppress_warnings: ["mystnb.unknown_mime_type", "myst.domains", "mystnb.mime_priority"]
     copybutton_prompt_text: "$"
     nb_execution_show_tb: True
-    html_last_updated_fmt: "%b %d, %Y"
     nb_execution_timeout: 120
     html_extra_path:
       - images/badge.svg

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -71,6 +71,7 @@ sphinx:
     suppress_warnings: ["mystnb.unknown_mime_type", "myst.domains", "mystnb.mime_priority"]
     copybutton_prompt_text: "$"
     nb_execution_show_tb: True
+    html_last_updated_fmt: "%b %d, %Y"
     nb_execution_timeout: 120
     html_extra_path:
       - images/badge.svg

--- a/jupyter_book/default_config.yml
+++ b/jupyter_book/default_config.yml
@@ -90,3 +90,4 @@ sphinx:
   local_extensions          :   # A list of local extensions to load by sphinx specified by "name: path" items
   recursive_update          : false # A boolean indicating whether to overwrite the Sphinx config (true) or recursively update (false)
   config                    :   # key-value pairs to directly over-ride the Sphinx configuration
+      html_last_updated_fmt: "%b %d, %Y"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -52,7 +52,6 @@ def test_build_from_template(temp_with_override, cli):
     assert html.joinpath("intro.html").exists()
 
 
-@pytest.mark.xfail(strict=True)
 def test_last_updated_fmt_is_not_None_from_default_template(temp_with_override, cli):
     """Test building the book template and a few test configs."""
     # Create the book from the template

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import pytest
@@ -49,6 +50,22 @@ def test_build_from_template(temp_with_override, cli):
     html = book.joinpath("_build", "html")
     assert html.joinpath("index.html").exists()
     assert html.joinpath("intro.html").exists()
+
+
+@pytest.mark.xfail(strict=True)
+def test_last_updated_fmt_is_not_None_from_default_template(temp_with_override, cli):
+    """Test building the book template and a few test configs."""
+    # Create the book from the template
+    book = temp_with_override / "new_book"
+    _ = cli.invoke(commands.create, book.as_posix())
+    build_result = cli.invoke(
+        commands.build, [book.as_posix(), "-n", "-W", "--keep-going"]
+    )
+    assert build_result.exit_code == 0, build_result.output
+    html = book.joinpath("_build", "html", "intro.html").read_text(encoding="utf8")
+    pattern = re.compile(r"Last updated on (?P<date>(\w+\s*)*)")
+    match = re.search(pattern, html)
+    assert match["date"] != "None"
 
 
 def test_build_dirhtml_from_template(temp_with_override, cli):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -53,7 +53,7 @@ def test_build_from_template(temp_with_override, cli):
 
 
 def test_last_updated_fmt_is_not_None_from_default_template(temp_with_override, cli):
-    """Test building the book template and a few test configs."""
+    """Test that the date is properly rendered in the footer"""
     # Create the book from the template
     book = temp_with_override / "new_book"
     _ = cli.invoke(commands.create, book.as_posix())

--- a/tests/test_config/test_config_sphinx_command.txt
+++ b/tests/test_config/test_config_sphinx_command.txt
@@ -12,6 +12,7 @@ external_toc_exclude_missing = False
 external_toc_path = '_toc.yml'
 html_baseurl = ''
 html_favicon = ''
+html_last_updated_fmt = '%b %d, %Y'
 html_logo = ''
 html_sourcelink_suffix = ''
 html_theme = 'sphinx_book_theme'

--- a/tests/test_config/test_config_sphinx_command_only_build_toc_files.txt
+++ b/tests/test_config/test_config_sphinx_command_only_build_toc_files.txt
@@ -12,6 +12,7 @@ external_toc_exclude_missing = False
 external_toc_path = '_toc.yml'
 html_baseurl = ''
 html_favicon = ''
+html_last_updated_fmt = '%b %d, %Y'
 html_logo = ''
 html_sourcelink_suffix = ''
 html_theme = 'sphinx_book_theme'

--- a/tests/test_config/test_get_final_config_custom_myst_extensions.yml
+++ b/tests/test_config/test_get_final_config_custom_myst_extensions.yml
@@ -28,6 +28,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: sphinx_book_theme

--- a/tests/test_config/test_get_final_config_empty_.yml
+++ b/tests/test_config/test_get_final_config_empty_.yml
@@ -25,6 +25,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: sphinx_book_theme

--- a/tests/test_config/test_get_final_config_exclude_patterns_.yml
+++ b/tests/test_config/test_get_final_config_exclude_patterns_.yml
@@ -28,6 +28,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: sphinx_book_theme

--- a/tests/test_config/test_get_final_config_execute_method_.yml
+++ b/tests/test_config/test_get_final_config_execute_method_.yml
@@ -27,6 +27,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: sphinx_book_theme

--- a/tests/test_config/test_get_final_config_extended_syntax_.yml
+++ b/tests/test_config/test_get_final_config_extended_syntax_.yml
@@ -29,6 +29,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: sphinx_book_theme

--- a/tests/test_config/test_get_final_config_html_extra_footer_.yml
+++ b/tests/test_config/test_get_final_config_html_extra_footer_.yml
@@ -27,6 +27,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: sphinx_book_theme

--- a/tests/test_config/test_get_final_config_latex_doc_.yml
+++ b/tests/test_config/test_get_final_config_latex_doc_.yml
@@ -29,6 +29,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: sphinx_book_theme

--- a/tests/test_config/test_get_final_config_launch_buttons_.yml
+++ b/tests/test_config/test_get_final_config_launch_buttons_.yml
@@ -27,6 +27,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: sphinx_book_theme

--- a/tests/test_config/test_get_final_config_repository_.yml
+++ b/tests/test_config/test_get_final_config_repository_.yml
@@ -27,6 +27,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: sphinx_book_theme

--- a/tests/test_config/test_get_final_config_sphinx_default_.yml
+++ b/tests/test_config/test_get_final_config_sphinx_default_.yml
@@ -40,6 +40,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: other

--- a/tests/test_config/test_get_final_config_sphinx_recurse_.yml
+++ b/tests/test_config/test_get_final_config_sphinx_recurse_.yml
@@ -39,6 +39,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: other

--- a/tests/test_config/test_get_final_config_title_.yml
+++ b/tests/test_config/test_get_final_config_title_.yml
@@ -26,6 +26,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: sphinx_book_theme

--- a/tests/test_config/test_mathjax_config_warning.sphinx4.yml
+++ b/tests/test_config/test_mathjax_config_warning.sphinx4.yml
@@ -31,6 +31,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: sphinx_book_theme

--- a/tests/test_config/test_mathjax_config_warning.sphinx5.yml
+++ b/tests/test_config/test_mathjax_config_warning.sphinx5.yml
@@ -31,6 +31,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: sphinx_book_theme

--- a/tests/test_config/test_mathjax_config_warning_mathjax2path.sphinx4.yml
+++ b/tests/test_config/test_mathjax_config_warning_mathjax2path.sphinx4.yml
@@ -32,6 +32,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: sphinx_book_theme

--- a/tests/test_config/test_mathjax_config_warning_mathjax2path.sphinx5.yml
+++ b/tests/test_config/test_mathjax_config_warning_mathjax2path.sphinx5.yml
@@ -32,6 +32,7 @@ final:
   external_toc_exclude_missing: false
   html_baseurl: ''
   html_favicon: ''
+  html_last_updated_fmt: '%b %d, %Y'
   html_logo: ''
   html_sourcelink_suffix: ''
   html_theme: sphinx_book_theme


### PR DESCRIPTION
Currently the default template does not add anything for [`html_last_updated_fmt`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_last_updated_fmt)

 This can for example be seen from jupyter-book's documention which shows *Last updated None* in the footer (see screenshot). 
<img width="547" alt="Screenshot 2023-03-04 at 20 11 47" src="https://user-images.githubusercontent.com/2010323/222924584-81b4daa6-ef9b-4313-99bf-55bf0b8c1a29.png">

This PR just adds the date and year in the default template