### PR TITLE
RELEASE: v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## v0.15.1 - 2023-03-09
+
+([full changelog](https://github.com/executablebooks/jupyter-book/compare/v0.15.0...aa0eedbc40691b5f0ea0dd5e80fdfb572e0ee91d))
+
+This release is a minor update to pin `docutils < 0.18` until an issue is resolved in
+the [sphinxcontrib-bibtex #322](https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/322)
+is resolved.
+
+**Bug:** Using `docutils>=0.18` results in breaking the page `html` layout when using `sphinx-book-theme` on pages
+that include a `bibliography` directive.
+
+
 ## v0.15.0 - 2023-03-07
 
 ([full changelog](https://github.com/executablebooks/jupyter-book/compare/v0.14.0...c0d3d0c640a709f84c23ef58b25c65d2e5a6e816))

--- a/jupyter_book/__init__.py
+++ b/jupyter_book/__init__.py
@@ -1,6 +1,6 @@
 """Build a book with Jupyter Notebooks and Sphinx."""
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"
 
 
 # We connect this function to the step after the builder is initialized

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dynamic = ["description", "version"]
 requires-python = ">=3.7"
 dependencies = [
     "click>=7.1,<9",
-    "docutils>=0.15,<0.19",
+    "docutils>=0.15,<0.18", # needs to be <0.18 until https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/322 is fixed
     "Jinja2",
     "jsonschema<5",
     "linkify-it-py~=2.0.0",


### PR DESCRIPTION
This PR includes a minor bug fix due to interactions between `sphinxcontrib-bibtex` and `sphinx-book-theme` when using `docutils>=0.18`

This also includes updates to CHANGELOG and make a minor version increment in preparation for a new release. 

- [ ] check tests
- [ ] review docs (make a note re: `docutils`)