### PR TITLE
DOCS: fix intro broken links

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -266,7 +266,7 @@ We have community discussions, talk about ideas, and share general questions and
 :::
 
 :::{grid-item-card}
-:link: https://executablebooks.org/en/latest/feature-vote.html
+:link: https://executablebooks.org/en/latest/feature-vote/
 :class-header: bg-light
 
 👍 Vote for new features

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -277,7 +277,8 @@ You can find a list of the top issues in the Executable Books issue leader board
 :::
 
 :::{grid-item-card}
-:link: contribute/intro.md
+:link: contribute/intro
+:link-type: doc
 :class-header: bg-light
 
 🙌 Contribute to projects


### PR DESCRIPTION
I found two broken links in the intro:

<img width="802" alt="image" src="https://user-images.githubusercontent.com/29252289/224268232-44d6813a-8055-415e-b1f1-73977684bfae.png">

I changed the feature vote link (
https://executablebooks.org/en/latest/feature-vote.html -> https://executablebooks.org/en/latest/feature-vote/

Not sure about the contribute link
contribute/intro.md -> ? 
with this I land on https://jupyterbook.org/en/latest/contribute/intro.md which fails. I should land on https://jupyterbook.org/en/latest/contribute/intro.html I guess but no sure how to edit the source code here though.
