### PR TITLE
CI: adding python 3.10 to the testing matrix and tox

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         sphinx: [">=4,<5", ">=5,<6"]
 
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ envlist = py39-sphinx4
 usedevelop = true
 passenv=TERM
 
-[testenv:py{37,38,39}-sphinx{4,5}]
+[testenv:py{37,38,39,310}-sphinx{4,5}]
 extras = testing
 deps =
     sphinx4: sphinx>=4,<5


### PR DESCRIPTION
This should close https://github.com/executablebooks/jupyter-book/issues/1504

Things I wonder about:
 - why isn't tox utilized in the CI config?
 - should also try adding python 3.11, I'll do that once 3.10 is all good to go.