### PR TITLE
[DOC] persist execution cache on github actions

### DIFF
--- a/docs/publish/gh-pages.md
+++ b/docs/publish/gh-pages.md
@@ -169,6 +169,16 @@ jobs:
       run: |
         pip install -r requirements.txt
 
+    # (optional) cache your executed notebooks between runs
+    # if you have config:
+    # execute:
+    #   execute_notebooks: cache
+    - name: cache executed notebooks
+      uses: actions/cache@v3
+      with:
+        path: _build/.jupyter_cache
+        key: jupyter-book-cache-${{ hashFiles('requirements.txt') }}
+
     # Build the book
     - name: Build the book
       run: |


### PR DESCRIPTION
I looked for an example for this, and didn't find it. Turns out to work without much fiddling! https://github.com/scientificcomputing/mpi-tutorial/pull/31

I'm not sure if there's another place to mention this, e.g. in [execution#cache](https://jupyterbook.org/en/stable/content/execute.html#caching-the-notebook-execution)?

I don't know if there are any issues with caching this way. It seems like one might want jupyter-cache entries to expire individually, but I don't think they do?