### PR TITLE
Typo fixes and formatting for migration.md

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,16 @@ repos:
     rev: 6.0.0
     hooks:
     - id: flake8
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+    - id: codespell
+      # Allow inline ignores for spelling lines
+      args: ["--ignore-regex", "^.{1024}|^.*\\!ignore-spelling|RePEc:the:publsh:1367"]
+      exclude: >
+        (?x)^(
+            tests/.*|
+            .*\.bib|
+            CHANGELOG.md
+        )$

--- a/docs/advanced/pdf.md
+++ b/docs/advanced/pdf.md
@@ -240,7 +240,7 @@ contains a full list of supported `latex` builders.
 #### Customize LaTeX via Sphinx
 
 The current focus of the EBP project has been to automate the process of building `pdf` files
-from `myst:md` sources and to ensure the resulting `pdf` files are syncronised (in structure)
+from `myst:md` sources and to ensure the resulting `pdf` files are synchronised (in structure)
 with the `html` output. We are actively looking at ways to enable more `LaTeX` configuration and
 customization.
 

--- a/docs/content/code-outputs.md
+++ b/docs/content/code-outputs.md
@@ -19,7 +19,7 @@ Below we give examples of how to format particular outputs and even insert outpu
 The [MyST cheat sheet](myst_cheatsheet) provides a [list of `code-cell` tags available](myst_cheatsheet:code-cell:tags)
 
 :::{seealso}
-The [MyST-NB documentation](myst-nb:render/output/cutomise), for how to fully customize the output renderer.
+The [MyST-NB documentation](myst-nb:render/output/customise), for how to fully customize the output renderer.
 :::
 
 (content:code-outputs:library-outputs)=

--- a/docs/content/content-blocks.md
+++ b/docs/content/content-blocks.md
@@ -416,7 +416,7 @@ For example:
 
 #### Create more complex index entries
 
-The Sphinx [*Index-generating markup*](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html?highlight=index#index-generating-markup) page describes the full range of indexing possibilites.
+The Sphinx [*Index-generating markup*](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html?highlight=index#index-generating-markup) page describes the full range of indexing possibilities.
 This includes the ability to construct nested headings using the `;` separator to represent a change in index level:
 
 ````md

--- a/docs/content/executable/output-insert.md
+++ b/docs/content/executable/output-insert.md
@@ -37,7 +37,7 @@ It follows a two-step process:
 
 * **Glue a variable to a name**. Do this by using
   the `myst_nb.glue` function on a variable
-  that you'd like to re-use elsewhere in the book. You'll give the variable
+  that you'd like to reuse elsewhere in the book. You'll give the variable
   a name that can be referenced later.
 * **Reference that variable from your page's content**. Then, when you are
   writing your content, insert the variable into your text by using a

--- a/docs/content/figures.md
+++ b/docs/content/figures.md
@@ -198,7 +198,7 @@ which will replace the reference with the figure caption like so:
 ### Numbered references
 
 Another convenient way to create cross-references is with the `{numref}` role,
-which referes to the labelled objects by the numbers they automatically get.
+which refers to the labelled objects by the numbers they automatically get.
 For example, `` {numref}`directive-fig` `` will produce a reference like: {numref}`directive-fig`.
 
 If an explicit text is provided, this caption will serve as the title of the reference. For example,

--- a/docs/contribute/intro.md
+++ b/docs/contribute/intro.md
@@ -175,7 +175,7 @@ what kinds of functionality they support:
 * {term}`The MyST-NB package<MyST-NB>` parses Jupyter Notebooks into Sphinx and also
   controls some parts of notebook execution.
   It also allows [inserting code outputs into content](content:executable:output-insert).
-* {term}`Jupyter-Cache` manages the execution and cacheing of notebook content at
+* {term}`Jupyter-Cache` manages the execution and caching of notebook content at
   build time. It is controlled by {term}`MyST-NB`.
 * The {term}`Sphinx Book Theme` defines the look and feel of Jupyter Book, and is
   where most of the CSS rules are defined.

--- a/docs/explain/migration.md
+++ b/docs/explain/migration.md
@@ -5,9 +5,9 @@ This release of `jupyter-book>=0.14` includes major updates to [myst-nb](https:/
 and [myst-parser](https://myst-parser.readthedocs.io/en/latest/) that include some **breaking changes**.
 
 This update includes incorporating three major updates to [myst-nb](https://github.com/executablebooks/myst-nb) moving from `myst-nb~=0.13.1` to `myst-nb~=0.17.1`
-which incporates changes to the underlying [myst-parser](https://github.com/executablebooks/myst-parser) moving from `myst-parser~=0.15` to `myst-parser~=0.18`.
+which incorporates changes to the underlying [myst-parser](https://github.com/executablebooks/myst-parser) moving from `myst-parser~=0.15` to `myst-parser~=0.18`.
 
-While every effort has been made to enable backward compatibility there are some new warnings
+While every effort has been made to enable backward compatibility, there are some new warnings
 that may appear when upgrading to the latest version. This page has been put together to help explain
 these warnings and provides suggestions on how to fix them.
 
@@ -51,7 +51,7 @@ The noteworthy configuration changes which effected most of our projects were:
 2. `nb_render_priority` is renamed to `nb_mime_priority_overrides` and it accepts a sequence of tuples.
     Each tuple takes three mandatory entries namely `builder name`, `mime type`, and `priority`.
 
-  An Example,
+  An Example:
 
   ```yaml
   sphinx:
@@ -68,7 +68,7 @@ The noteworthy configuration changes which effected most of our projects were:
         - "text/plain"
   ```
 
-  would become
+  would become:
 
   ```yaml
   sphinx:
@@ -98,7 +98,7 @@ Some examples follow:
 
 #### myst-nb
 
-To set the `execution_timeout` config option managed by `mystnb` you would specify the following
+To set the `execution_timeout` config option managed by `mystnb` you would specify the following:
 
 ````md
 ```
@@ -115,7 +115,7 @@ in the header of the notebook (or page).
 #### Myst-parser
 
 To make document level variables that will be resolved by [myst-parser](https://github.com/executablebooks/myst-parser)
-then this configuration can be specifed under the `myst` key in the configuration for each notebook (or page) such as:
+then this configuration can be specified under the `myst` key in the configuration for each notebook (or page) such as:
 
 ````md
 ```
@@ -148,7 +148,7 @@ Since cell-level operations are in myst-nb domain, we don't have to worry about 
 
 This changes the way configuration was previously captured under the `render` title, replacing it with `mystnb`.
 
-An example of the new configuration
+An example of the new configuration:
 
 ````md
 ```{code-cell} ipython3
@@ -212,11 +212,11 @@ in some other `sphinx/docutils` directives
 
 #### Limitations for Figures and Math
 
-There are current limitations based on the `mime` types for `Figures` and `Math`
+There are currently some limitations based on the `mime` types for `Figures` and `Math`.
 
 **Math:**
 
-Using the `glue` directive between documents for math results in a text representation
+Using the `glue` directive between documents for math results in a text representation:
 
 ```{glue} sym_eq
 :doc: /content/executable/output-insert.md
@@ -224,9 +224,9 @@ Using the `glue` directive between documents for math results in a text represen
 
 **Figures:**
 
-Similary for Figures
+The resultant text representation when using the `glue` directive is similar for figures.
 
-For example if you glue in the figure `sorted_means_fig` from the `executable/output-insert.md` document
+For example, if you glue in the figure `sorted_means_fig` from the `executable/output-insert.md` document:
 
 ````md
 ```{glue} sorted_means_fig
@@ -234,7 +234,7 @@ For example if you glue in the figure `sorted_means_fig` from the `executable/ou
 ```
 ````
 
-will render as
+it will be rendered as:
 
 ```{glue} sorted_means_fig
 :doc: /content/executable/output-insert.md
@@ -242,4 +242,4 @@ will render as
 
 which is the text description of the image.
 
-These issues have been reported to the myst-nb team
+These issues have been reported to the myst-nb team.

--- a/docs/file-types/notebooks.ipynb
+++ b/docs/file-types/notebooks.ipynb
@@ -105,7 +105,7 @@
     "fig, ax = plt.subplots(figsize=(10, 5))\n",
     "lines = ax.plot(data)\n",
     "ax.legend(custom_lines, ['Cold', 'Medium', 'Hot'])\n",
-    "ax.set(title=\"Smoother linez\")"
+    "ax.set(title=\"Smoother lines\")"
    ]
   },
   {

--- a/docs/publish/netlify.md
+++ b/docs/publish/netlify.md
@@ -19,7 +19,7 @@ Books, you might want to consider registering for [a paid account](https://www.n
 ```
 
 In order to use Netlify, you'll need to [create an account](https://app.netlify.com/signup).
-Here, we'll walk through connecting your Jupyter Book to Netlify's continous deployment services using their UI.
+Here, we'll walk through connecting your Jupyter Book to Netlify's continuous deployment services using their UI.
 You can also check out their [documentation on continuous deployment](https://www.netlify.com/docs/continuous-deployment/).
 
 ```{warning}

--- a/docs/start/build.md
+++ b/docs/start/build.md
@@ -65,7 +65,7 @@ The best practice for publishing your book is to use separate branches for your 
 For example, you may tell git to ignore your `_build` folder on your `main` branch, and push the outputs in your `_build` folder to a branch called `gh-pages`.
 We'll cover some of this later on.
 
-:::{admonition} A note on page cacheing
+:::{admonition} A note on page caching
 :class: tip
 By default, Jupyter Book will only build the HTML for pages that have
 been updated since the last time you built the book.

--- a/docs/start/create.md
+++ b/docs/start/create.md
@@ -73,7 +73,7 @@ bibtex_bibfiles:
 - `title:` defines a title for the book. It will show up in the left sidebar.
 - `author:` adds the author's name to your book template, for attribution.
 - `logo:` defines a path to an image file for your book's logo (it will also show up in the sidebar).
-- `execute:` contains a collection of configuration options to control [execution and cacheing](../content/execute.md).
+- `execute:` contains a collection of configuration options to control [execution and caching](../content/execute.md).
   - `execute_notebooks: "force"` tells Jupyter Book **force execute** any computational content each time it builds the book. By default, Jupyter Book executes and **caches** all book content.
 - `bibtex_bibfiles:`is a section to define bibliography files for your Jupyter Book.
   This configuration activates **citations** for your book (see [](../tutorials/references.md) for getting started with citations and references).

--- a/jupyter_book/config.py
+++ b/jupyter_book/config.py
@@ -149,7 +149,7 @@ def get_final_config(
             "mathjax_path" in user_yaml_update
             and "@2" in user_yaml_update["mathjax_path"]
         ):
-            # use mathjax2_config so not to tigger deprecation warning in future
+            # use mathjax2_config so not to trigger deprecation warning in future
             user_yaml_update["mathjax2_config"] = user_yaml_update.pop("mathjax_config")
         else:
             _message_box(

--- a/jupyter_book/sphinx.py
+++ b/jupyter_book/sphinx.py
@@ -153,7 +153,7 @@ def build_sphinx(
                     site_map = app.config.external_site_map
                     site_map_str = yaml.dump(site_map.as_json())
 
-                    # only if there is atleast one numbered: true in the toc file
+                    # only if there is at least one numbered: true in the toc file
                     if "numbered: true" in site_map_str:
                         app.setup_extension("sphinx_multitoc_numbering")
                 else:


### PR DESCRIPTION
A few minor typo fixes (spelling) and some punctuation improvements/recommendations.