### PR TITLE
Update copyright year to 2023

### DIFF
--- a/jupyter_book/default_config.yml
+++ b/jupyter_book/default_config.yml
@@ -7,7 +7,7 @@
 # Book settings
 title                       : My Jupyter Book  # The title of the book. Will be placed in the left navbar.
 author                      : The Jupyter Book community  # The author of the book
-copyright                   : "2022"  # Copyright year to be placed in the footer
+copyright                   : "2023"  # Copyright year to be placed in the footer
 logo                        : ""  # A path to the book logo
 # Patterns to skip when building the book. Can be glob-style (e.g. "*skip.ipynb")
 exclude_patterns            : [_build, Thumbs.db, .DS_Store, "**.ipynb_checkpoints"]

--- a/tests/test_config/test_config_sphinx_command.txt
+++ b/tests/test_config/test_config_sphinx_command.txt
@@ -5,7 +5,7 @@
 ###############################################################################
 author = 'The Jupyter Book community'
 comments_config = {'hypothesis': False, 'utterances': False}
-copyright = '2022'
+copyright = '2023'
 exclude_patterns = ['**.ipynb_checkpoints', '.DS_Store', 'Thumbs.db', '_build']
 extensions = ['sphinx_togglebutton', 'sphinx_copybutton', 'myst_nb', 'jupyter_book', 'sphinx_thebe', 'sphinx_comments', 'sphinx_external_toc', 'sphinx.ext.intersphinx', 'sphinx_design', 'sphinx_book_theme', 'sphinx_jupyterbook_latex']
 external_toc_exclude_missing = False

--- a/tests/test_config/test_config_sphinx_command_only_build_toc_files.txt
+++ b/tests/test_config/test_config_sphinx_command_only_build_toc_files.txt
@@ -5,7 +5,7 @@
 ###############################################################################
 author = 'The Jupyter Book community'
 comments_config = {'hypothesis': False, 'utterances': False}
-copyright = '2022'
+copyright = '2023'
 exclude_patterns = ['**.ipynb_checkpoints', '.DS_Store', 'Thumbs.db', '_build', 'test_config/*']
 extensions = ['sphinx_togglebutton', 'sphinx_copybutton', 'myst_nb', 'jupyter_book', 'sphinx_thebe', 'sphinx_comments', 'sphinx_external_toc', 'sphinx.ext.intersphinx', 'sphinx_design', 'sphinx_book_theme', 'sphinx_jupyterbook_latex']
 external_toc_exclude_missing = False

--- a/tests/test_config/test_get_final_config_custom_myst_extensions.yml
+++ b/tests/test_config/test_get_final_config_custom_myst_extensions.yml
@@ -7,7 +7,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store

--- a/tests/test_config/test_get_final_config_empty_.yml
+++ b/tests/test_config/test_get_final_config_empty_.yml
@@ -4,7 +4,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store

--- a/tests/test_config/test_get_final_config_exclude_patterns_.yml
+++ b/tests/test_config/test_get_final_config_exclude_patterns_.yml
@@ -6,7 +6,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store

--- a/tests/test_config/test_get_final_config_execute_method_.yml
+++ b/tests/test_config/test_get_final_config_execute_method_.yml
@@ -6,7 +6,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store

--- a/tests/test_config/test_get_final_config_extended_syntax_.yml
+++ b/tests/test_config/test_get_final_config_extended_syntax_.yml
@@ -8,7 +8,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store

--- a/tests/test_config/test_get_final_config_html_extra_footer_.yml
+++ b/tests/test_config/test_get_final_config_html_extra_footer_.yml
@@ -6,7 +6,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store

--- a/tests/test_config/test_get_final_config_latex_doc_.yml
+++ b/tests/test_config/test_get_final_config_latex_doc_.yml
@@ -8,7 +8,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store

--- a/tests/test_config/test_get_final_config_launch_buttons_.yml
+++ b/tests/test_config/test_get_final_config_launch_buttons_.yml
@@ -6,7 +6,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store

--- a/tests/test_config/test_get_final_config_repository_.yml
+++ b/tests/test_config/test_get_final_config_repository_.yml
@@ -6,7 +6,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store

--- a/tests/test_config/test_get_final_config_sphinx_default_.yml
+++ b/tests/test_config/test_get_final_config_sphinx_default_.yml
@@ -17,7 +17,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store

--- a/tests/test_config/test_get_final_config_sphinx_recurse_.yml
+++ b/tests/test_config/test_get_final_config_sphinx_recurse_.yml
@@ -16,7 +16,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store

--- a/tests/test_config/test_get_final_config_title_.yml
+++ b/tests/test_config/test_get_final_config_title_.yml
@@ -5,7 +5,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store

--- a/tests/test_config/test_mathjax_config_warning.sphinx4.yml
+++ b/tests/test_config/test_mathjax_config_warning.sphinx4.yml
@@ -10,7 +10,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store

--- a/tests/test_config/test_mathjax_config_warning.sphinx5.yml
+++ b/tests/test_config/test_mathjax_config_warning.sphinx5.yml
@@ -10,7 +10,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store

--- a/tests/test_config/test_mathjax_config_warning_mathjax2path.sphinx4.yml
+++ b/tests/test_config/test_mathjax_config_warning_mathjax2path.sphinx4.yml
@@ -11,7 +11,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store

--- a/tests/test_config/test_mathjax_config_warning_mathjax2path.sphinx5.yml
+++ b/tests/test_config/test_mathjax_config_warning_mathjax2path.sphinx5.yml
@@ -11,7 +11,7 @@ final:
   comments_config:
     hypothesis: false
     utterances: false
-  copyright: '2022'
+  copyright: '2023'
   exclude_patterns:
   - '**.ipynb_checkpoints'
   - .DS_Store


### PR DESCRIPTION
Pretty straightforward PR I hope. Big fan of the project all.

I noticed that copyrights seem to be set to 2022 across the whole EB project, but this should update the docs and tests to reference 2023.