### PR TITLE
bump docutils

### DIFF
--- a/docs/content/citations.md
+++ b/docs/content/citations.md
@@ -1,19 +1,6 @@
 (content:citations)=
 # Citations and bibliographies
 
-:::{warning}
-If you are using `docutils<=0.18,<20` then the page containing the `bibliography` directive
-will not have the correct layout. While `docutils` is patched we recommend using `docutils==0.17.1`
-which can be installed by:
-
-```bash
-pip install docutils==0.17.1
-```
-
-This is due to [this issue](https://sourceforge.net/p/docutils/patches/195/)
-:::
-
-
 You can add citations and bibliographies using references that are stored in a `bibtex` file that is in your book's folder. You can then add a citation in-line in your Markdown with the `{cite}` role, and include the bibliography from your bibtex file with the `{bibliography}` directive.
 
 ```{seealso}

--- a/jupyter_book/config.py
+++ b/jupyter_book/config.py
@@ -421,12 +421,11 @@ def yaml_to_sphinx(yaml: dict):
         # Report Bug in Specific Docutils Versions
         # TODO: Remove when docutils>=0.20 is pinned in jupyter-book
         # https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/322
-        if (0, 18) <= docutils.__version_info__ < (0, 20):
+        if (0, 18) <= docutils.__version_info__ < (0, 20, 1):
             logger.warn(
-                "[sphinxcontrib-bibtex] Beware that docutils versions 0.18 and 0.19 "
+                "[sphinxcontrib-bibtex] Beware that docutils versions 0.18, 0.19, and 0.20.0 "
                 "(you are running {}) are known to generate invalid html for citations. "
-                "If this issue affects you, please use docutils<0.18 (or >=0.20 once released) "
-                "instead. "
+                "If this issue affects you, please use docutils<0.18 or >=0.20.1 instead. "
                 "For more details, see https://sourceforge.net/p/docutils/patches/195/".format(
                     docutils.__version__
                 )

--- a/jupyter_book/config.py
+++ b/jupyter_book/config.py
@@ -421,11 +421,11 @@ def yaml_to_sphinx(yaml: dict):
         # Report Bug in Specific Docutils Versions
         # TODO: Remove when docutils>=0.20 is pinned in jupyter-book
         # https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/322
-        if (0, 18) <= docutils.__version_info__ < (0, 20, 1):
+        if (0, 18) <= docutils.__version_info__ < (0, 20):
             logger.warn(
-                "[sphinxcontrib-bibtex] Beware that docutils versions 0.18, 0.19, and 0.20.0 "
+                "[sphinxcontrib-bibtex] Beware that docutils versions 0.18 and 0.19 "
                 "(you are running {}) are known to generate invalid html for citations. "
-                "If this issue affects you, please use docutils<0.18 or >=0.20.1 instead. "
+                "If this issue affects you, please use docutils<0.18 or >=0.20 instead. "
                 "For more details, see https://sourceforge.net/p/docutils/patches/195/".format(
                     docutils.__version__
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dynamic = ["description", "version"]
 requires-python = ">=3.7"
 dependencies = [
     "click>=7.1,<9",
-    "docutils>=0.15,!=0.18.*,!=0.19.*,!=0.20.0",
+    "docutils>=0.15,!=0.18.*,!=0.19.*",
     "Jinja2",
     "jsonschema<5",
     "linkify-it-py~=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "linkify-it-py~=2.0.0",
     "myst-nb~=0.17.1",
     "pyyaml",
-    "sphinx>=4,<6",
+    "sphinx>=4,!=6.*,!=7.0.0",
     "sphinx-comments",
     "sphinx-copybutton",
     "sphinx-external-toc~=0.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dynamic = ["description", "version"]
 requires-python = ">=3.7"
 dependencies = [
     "click>=7.1,<9",
-    "docutils>=0.15,<0.19", # report issue for >=0.18,<0.20 until https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/322 is fixed
+    "docutils>=0.15,!=0.18.*,!=0.19.*,!=0.20.0",
     "Jinja2",
     "jsonschema<5",
     "linkify-it-py~=2.0.0",

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -76,7 +76,7 @@ def test_build_singlehtml_from_template(temp_with_override, cli):
     )
     # TODO: Remove when docutils>=0.20 is pinned in jupyter-book
     # https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/322
-    if (0, 18) <= docutils.__version_info__ < (0, 20):
+    if (0, 18) <= docutils.__version_info__ < (0, 20, 1):
         assert build_result.exit_code == 1, build_result.output
     else:
         assert build_result.exit_code == 0, build_result.output

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -76,7 +76,7 @@ def test_build_singlehtml_from_template(temp_with_override, cli):
     )
     # TODO: Remove when docutils>=0.20 is pinned in jupyter-book
     # https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/322
-    if (0, 18) <= docutils.__version_info__ < (0, 20, 1):
+    if (0, 18) <= docutils.__version_info__ < (0, 20):
         assert build_result.exit_code == 1, build_result.output
     else:
         assert build_result.exit_code == 0, build_result.output


### PR DESCRIPTION
Allow `docutils>=0.20`, which includes the patch from https://sourceforge.net/p/docutils/patches/195

- reverts #1965
- fixes #1970
- fixes #1997
- fixes #2022
- fixes #2026
- fixes #2037

Though technically a similar PR to bump `docutils` will be required in https://github.com/sphinx-doc/sphinx and https://github.com/executablebooks/MyST-Parser to really fix the above issues.

**EDIT**: thanks to https://github.com/sphinx-doc/sphinx/pull/11411 it seems we also need `sphinx>=7.0.1` here... is that feasible?