### PR TITLE
fix: update `output_scroll` tag

### DIFF
--- a/docs/content/code-outputs.md
+++ b/docs/content/code-outputs.md
@@ -79,7 +79,7 @@ tag to a cell's metadata:
 ```json
 {
     "tags": [
-        "output_scroll",
+        "scroll-output",
     ]
 }
 ```
@@ -87,18 +87,18 @@ tag to a cell's metadata:
 For example, the following cell has a long output, but will be scrollable in the book:
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
+:tags: [scroll-output]
 
 for ii in range(40):
     print(f"this is output line {ii}")
 ```
 
-When writing MyST markdown documents you may use `:tags: ["output_scroll"]` as an option
+When writing MyST markdown documents you may use `:tags: ["scroll-output"]` as an option
 to the `code-cell` directive such as:
 
 ````
 ```{code-cell} ipython3
-:tags: [output_scroll]
+:tags: [scroll-output]
 
 for ii in range(40):
     print(f"this is output line {ii}")

--- a/docs/reference/cheatsheet.md
+++ b/docs/reference/cheatsheet.md
@@ -884,11 +884,11 @@ The following `tags` can be applied to code cells by introducing them as options
     print("This is a test.")
     ```
     ````
-* - `"output_scroll"`
+* - `"scroll-output"`
   - Make output cell scrollable
   - ````md
     ```{code-cell} ipython3
-    :tags: ["output_scroll"]
+    :tags: ["scroll-output"]
     for ii in range(100):
       print("This is a test.")
     ```


### PR DESCRIPTION
This PR closes https://github.com/executablebooks/jupyter-book/issues/1850, by renaming out usage of `output_scroll`