### PR TITLE
Update gh-pages.md

### DIFF
--- a/docs/publish/gh-pages.md
+++ b/docs/publish/gh-pages.md
@@ -57,8 +57,6 @@ Here is a simple YAML configuration for a Github Action that will publish a Jupy
 ```yaml
 name: deploy-book
 
-name: deploy-book
-
 # Run this when the master or main branch changes
 on:
   push:


### PR DESCRIPTION
There was an error of syntax, two name: deploy-book were pass into yaml file, and that create an syntax error in github actions.
![Screenshot from 2024-01-30 17-49-06](https://github.com/executablebooks/jupyter-book/assets/43865479/d31e92a1-f268-4fc5-9da5-dbc273f7bdf8)
