### PR TITLE
DOCS: Ordering of cache step in GH Action YAML example

### DIFF
--- a/docs/publish/gh-pages.md
+++ b/docs/publish/gh-pages.md
@@ -94,7 +94,7 @@ jobs:
     - name: Build the book
       run: |
         jupyter-book build .
-        
+
     # (optional) Cache your executed notebooks between runs
     # if you have config:
     # execute:
@@ -103,7 +103,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: _build/.jupyter_cache
-        key: jupyter-book-cache-${{ hashFiles('requirements.txt') }}        
+        key: jupyter-book-cache-${{ hashFiles('requirements.txt') }}
 
     # Upload the book's HTML as an artifact
     - name: Upload artifact

--- a/docs/publish/gh-pages.md
+++ b/docs/publish/gh-pages.md
@@ -90,6 +90,11 @@ jobs:
       run: |
         pip install -r requirements.txt
 
+    # Build the book
+    - name: Build the book
+      run: |
+        jupyter-book build .
+        
     # (optional) Cache your executed notebooks between runs
     # if you have config:
     # execute:
@@ -98,12 +103,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: _build/.jupyter_cache
-        key: jupyter-book-cache-${{ hashFiles('requirements.txt') }}
-
-    # Build the book
-    - name: Build the book
-      run: |
-        jupyter-book build .
+        key: jupyter-book-cache-${{ hashFiles('requirements.txt') }}        
 
     # Upload the book's HTML as an artifact
     - name: Upload artifact


### PR DESCRIPTION
In the example GitHub Action YAML provided at the bottom of https://jupyterbook.org/en/stable/publish/gh-pages.html, the caching of executable content is placed before the `jupyter-book build .` command, when there are no outputs to cache at that point. This results in a GH action log message such as

```bash
Run actions/cache@v3
Cache not found for input keys: jupyter-book-cache-511116b794a1ce6b75d5156b58ce1314db3e65a10292d7e9f072cad18f7711b3
```

This PR places the caching step _after_ the `jupyter-book build .` , which should result in a successful GH action log message such as

```bash
Run actions/cache@v3
Cache Size: ~1 MB (1110285 B)
/usr/bin/tar -xf /home/runner/work/_temp/21854ee6-0f37-4c55-9aa7-0f64d703126c/cache.tzst -P -C /home/runner/work/czi-catalystproject.github.io/czi-catalystproject.github.io --use-compress-program unzstd
Cache restored successfully
Cache restored from key: jupyter-book-cache-511116b794a1ce6b75d5156b58ce1314db3e65a10292d7e9f072cad18f7711b3
```