### PR TITLE
✳️ Bump `NODEENV_VERSION`

### DIFF
--- a/py/jupyter_book/__main__.py
+++ b/py/jupyter_book/__main__.py
@@ -14,7 +14,7 @@ from .nodeenv import (
 
 __version__ = "2.0.0b2"
 
-NODEENV_VERSION = "18.0.0"
+NODEENV_VERSION = "22.17.0"
 
 
 def test_node_version(triple_version):


### PR DESCRIPTION
This corrects an issue which prevented --gh-pages from working correctly.

Originally fixed in https://github.com/jupyter-book/jupyter-book/pull/2383, but somehow this was clobbered.