### PR TITLE
Clarify GitHub Pages instructions

### DIFF
--- a/docs/publish/gh-pages.md
+++ b/docs/publish/gh-pages.md
@@ -115,7 +115,7 @@ jobs:
 
 ### Conda
 
-Here's how to build using [Conda (Anaconda)](https://docs.conda.io/projects/conda/en/stable/) with an [`environment.yml`](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-from-an-environment-yml-file). This assumes
+Here's how to build using [Conda (Anaconda)](https://docs.conda.io/projects/conda/en/stable/) with an [`environment.yml`](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-from-an-environment-yml-file).
 
 ```yaml
 name: deploy-book


### PR DESCRIPTION
Just took ~80 students through this and realized some bits could be clearer!

- Formats the file with [Prettier](https://prettier.io/)
- Eliminates the cookiecutter instructions from the deployment page
   - Presumably someone only comes to this page after they have a Book created.
- Adds headings
- Explains how to confirm it worked

Suggest [reviewing ignoring whitespace](https://github.com/jupyter-book/jupyter-book/pull/2421/files?w=1). Thanks!