### PR TITLE
CI: move on from deprecated macos image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         runs-on:
           - windows-latest
           - ubuntu-latest
-          - macos-13
+          - macos-latest
         python-version:
           - "3.13"
           - "3.12"


### PR DESCRIPTION
The runner is being deprecated and will get removed soon.