### PR TITLE
MAINT: dependabot PRs should auto pass label linting CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     groups:
       npm:
         patterns: ["*"]
+    labels:
+      - "maintenance"
+      - "javascript"
+      - "dependencies"
 
   # Enable version updates for Python
   - package-ecosystem: "pip"
@@ -24,3 +28,7 @@ updates:
     groups:
       pip:
         patterns: ["*"]
+    labels:
+      - "maintenance"
+      - "python"
+      - "dependencies"


### PR DESCRIPTION
These PRs should not get a failing status just because of missing triage labels