### PR TITLE
MAINT: adding cooldown for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "monthly"
+    # Make sure we don't just pull in freshly released versions
+    cooldown:
+      default-days: 14
     groups:
       npm:
         patterns: ["*"]
@@ -25,6 +28,8 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 14
     groups:
       pip:
         patterns: ["*"]


### PR DESCRIPTION
Seeing #2469 reminded me that we talked with @stefanv about adding a cooldown for updates to be at least somewhat safeguarded about malicious releases. 

Using 2 weeks feels like a good middle ground, but I'm not married to the actual number (IMO it should not be shorter -- if any version is critical enough to require ASAP updates, that can always be done manually by a maintainer).

If this is a thumbs up, I'm happy to take care of opening PRs to all/most of our other repos.