### PR TITLE
MAINT: exclude non-third-party packages from dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     # Make sure we don't just pull in freshly released versions
     cooldown:
       default-days: 14
+      exclude:
+        - "myst-cli"
     groups:
       npm:
         patterns: ["*"]


### PR DESCRIPTION
Does what's on the tin; in practice behaviour compare #2487 and #2486 