### PR TITLE
update myst tables plugin

### DIFF
--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -21,7 +21,7 @@ project:
     - src/directives.mjs
     - src/admonition.mjs
     # The issue tables plugin is what we use for the roadmap and feature voting pages
-    - https://github.com/jupyter-book/myst-plugins/releases/download/github-issue-table@2025-12-06/index.mjs
+    - https://github.com/jupyter-book/myst-plugins/releases/download/github-issue-table@2025-12-07/index.mjs
   github: https://github.com/jupyter-book/jupyter-book
   toc:
     - file: index.md


### PR DESCRIPTION
I'm pretty sure that we're hitting unauthorized errors and that's why the tables issues aren't showing up. So I updated myst-tables to show the error message if it gets it, and this PR updates to the latest release there. Let's see if that helps debug this. (cc @bsipocz )