### PR TITLE
Update top links to be more permanent

### DIFF
--- a/docs/_site/site.yml
+++ b/docs/_site/site.yml
@@ -3,16 +3,15 @@ site:
   template: book-theme
   nav:
     - title: Docs
-      url: /get-started
+      url: https://jupyterbook.org/stable/get-started
     - title: Community
-      url: /community
+      url: https://jupyterbook.org/stable/community
     - title: Ecosystem
-      url: /community/ecosystem
+      url: https://jupyterbook.org/stable/community/ecosystem
     - title: Contribute
-      url: /contribute
-    # Commenting this out while there's a bug that adds BASE_URL to the nav links
-    # - title: Blog
-    #   url: https://blog.jupyterbook.org
+      url: https://jupyterbook.org/stable/contribute
+    - title: Blog
+      url: https://blog.jupyterbook.org
     - title: Help
       children:
       - title: Ask a question ❓


### PR DESCRIPTION
This makes two changes to our navbar links:

- Hard-codes them to use `https://jupyterbook.org/stable`. This is because we re-use these links in blog.jupyterbook.org and it means the blog links are broken without the hard-coding
- Adds back in the blog link because we've fixed the BASE_URL bug that was causing it

This means that all navbar links will point to `/stable` regardless of whether they're on `latest/`. The other option would be to stop re-using the same navbar link configuration for the blog and instead to a copy/paste step.