### PR TITLE
Add `dolfiny` to gallery

### DIFF
--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -100,5 +100,5 @@
   website: https://dolfiny.uni.lu/
   repository: https://github.com/fenics-dolfiny/dolfiny
   image: https://github.com/fenics-dolfiny/dolfiny/blob/main/book/logo.svg
-  description: Computational mechanics demos of dolfiny, an extension module of the finite element library FEniCSx, rendered as juptyer book.
+  description: Computational mechanics demos of dolfiny, an extension module of the finite element library FEniCSx, rendered as jupyter book.
   tags: Computational Mechanics; FEniCS; Documentation; University of Luxembourg


### PR DESCRIPTION
Adds `dofliny` entry to gallery, hosted [here](https://dolfiny.uni.lu/) and based on this [repo](https://github.com/fenics-dolfiny/dolfiny). 