### PR TITLE
MAINT: adding more dependabot config to ensure less noise and passing PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
     labels:
       - "maintenance"
       - "dependencies"
+      - "github_actions"
 
   # Enable version updates for npm
   - package-ecosystem: "npm"


### PR DESCRIPTION
This is a follow-up to #2535; so we don't get half a dozen non-passing PRs from dependabot again.