### PR TITLE
Fix broken quick links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ Thank you for your interest in contributing to Jupyter Book!
 ## Quick Links
 
 **Contributing to the Jupyter Book project:**
-- See our [Contributing Guide](https://jupyterbook.org/en/stable/contribute/intro.html) for all ways to contribute (code, docs, community)
+- See our [Contributing Guide](https://jupyterbook.org/contribute/) for all ways to contribute (code, docs, community)
 
 **Contributing to THIS repository specifically:**
-- [Documentation Strategy Guide](https://jupyterbook.org/en/stable/contribute/docs.html) - THIS repo's docs structure, `nox` commands, style
-- [Code Contribution Guide](https://jupyterbook.org/en/stable/contribute/dev.html) - THIS repo's setup, architecture, development workflow
+- [Documentation Strategy Guide](https://jupyterbook.org/contribute/#documentation-contributions) - THIS repo's docs structure, `nox` commands, style
+- [Code Contribution Guide](https://jupyterbook.org/contribute/#code-contributions) - THIS repo's setup, architecture, development workflow


### PR DESCRIPTION
Quick links in CONTRIBUTING.md pointed to non-existent local documentation files. Updated them to the correct stable contributing documentation URLs.