### PR TITLE
Move some repo-specific documentation back here

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,5 +8,5 @@ Thank you for your interest in contributing to Jupyter Book!
 - See our [Contributing Guide](https://jupyterbook.org/contribute/) for all ways to contribute (code, docs, community)
 
 **Contributing to THIS repository specifically:**
-- [Documentation Strategy Guide](https://jupyterbook.org/contribute/#documentation-contributions) - THIS repo's docs structure, `nox` commands, style
-- [Code Contribution Guide](https://jupyterbook.org/contribute/#code-contributions) - THIS repo's setup, architecture, development workflow
+- [Documentation Strategy Guide](docs/contribute/docs.md) - THIS repo's docs structure, `nox` commands, style
+- [Code Contribution Guide](docs/contribute/code.md) - THIS repo's setup, architecture, development workflow

--- a/docs/contribute/code.md
+++ b/docs/contribute/code.md
@@ -1,0 +1,39 @@
+# Contributing Code to Jupyter Book
+
+This guide covers the technical setup and architecture for contributors to the `jupyter-book` repository.
+
+## Where code changes usually happen
+
+Most technical changes in the Jupyter Book ecosystem happen in one of these repositories:
+
+- [jupyter-book/mystmd](https://github.com/jupyter-book/mystmd): The document engine that powers Jupyter Book.
+- [jupyter-book/myst-theme](https://github.com/jupyter-book/myst-theme): The theme and React infrastructure used by Jupyter Book.
+- Other extension and plugin repositories in the [jupyter-book organization](https://github.com/jupyter-book).
+
+This repository (`jupyter-book/jupyter-book`) mainly provides a packaging and CLI distribution that is intentionally lightweight.
+
+## Application design
+
+The Jupyter Book application is a Python package that wraps a Node.js application. It is functionally equivalent to a configured version of the [MyST engine](https://github.com/jupyter-book/mystmd).
+
+### Python shim
+
+The Python package ensures users have Node.js to run the underlying application. For users without Node.js, it uses [`nodeenv`](https://github.com/ekalinin/nodeenv) to download a local copy.
+
+### CLI behavior
+
+Jupyter Book's CLI keeps compatibility-oriented behavior (for example, upgrade paths from Jupyter Book 1) while staying as close to upstream `mystmd` behavior as possible.
+
+## Build the Python package
+
+Jupyter Book uses [`hatch`](https://hatch.pypa.io/) to build the Python package. Configuration is in `pyproject.toml`, using plugins:
+
+- `hatch-jupyter-builder`: Builds the Node.js application.
+- `hatch-deps-selector`: Manages dependencies for conda-forge vs PyPI.
+- `hatch-nodejs-version`: Provides metadata from the JS package.
+
+Build the package:
+
+```shell
+hatch build
+```

--- a/docs/contribute/docs.md
+++ b/docs/contribute/docs.md
@@ -1,0 +1,61 @@
+# Documentation strategy and structure
+
+This guide covers documentation strategy for contributors working in the `jupyter-book` repository.
+
+## Scope of this repository
+
+The `docs/` folder in this repository is the canonical source for Jupyter Book user documentation served at:
+
+- `https://jupyterbook.org/stable` (latest release)
+- `https://jupyterbook.org/latest` (`main` branch)
+
+The `jupyterbook.org` repository remains the canonical home for community/organization pages (for example project history, contribution entry points, and team material).
+
+## Documentation structure
+
+Top-level pages in `docs/` represent major user journeys. For example:
+
+- `index.md`: Product landing page for users.
+- `get-started/`: Installation and first workflow.
+- `authoring/`: Content authoring.
+- `build-and-publish/`: Build and publishing workflows.
+- `execution/`: Computation and execution.
+- `plugins/`: Plugin architecture and extension points.
+- `resources/`: FAQs and reference resources.
+
+:::{note} Use `[folder].md` for section landing pages
+Instead of creating `authoring/index.md`, create `authoring.md` at the top level. This produces `/authoring` rather than `/authoring/index`.
+:::
+
+## Organizing content with Diataxis
+
+Within each topic area, organize content using [Diataxis](https://diataxis.fr/):
+
+- `tutorials`: Goal-oriented walkthroughs.
+- `how-to`: Task-focused guides.
+- `reference`: Technical and factual details.
+- `discussion`: Explanations and concepts.
+
+Keep folder hierarchy flat unless nesting is clearly necessary.
+
+## Local docs workflow
+
+This repository includes `nox` sessions for docs work.
+
+Build static HTML:
+
+```bash
+nox -s docs
+```
+
+Run live-reload development server:
+
+```bash
+nox -s docs-live
+```
+
+## Writing style
+
+- Prefer short, active language.
+- Keep pages scannable with descriptive headings.
+- Link to a single source of truth instead of duplicating content.

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -64,6 +64,10 @@ project:
         - file: resources/upgrade.md
         - file: resources/downgrade.md
         - file: resources/glossary.md
+    - title: Contributor Guide
+      children:
+        - file: contribute/code.md
+        - file: contribute/docs.md
 site:
   options:
     folders: true


### PR DESCRIPTION
This moves a few pieces of docs back here because they are too repo-specific to be in the jupyterbook.org repo