### PR TITLE
MAINT: limit dependabot updates to  myst only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,21 +20,16 @@ updates:
       - "dependencies"
       - "github_actions"
 
-  # Enable version updates for npm
+  # Enable version updates for npm, but only for myst; we don't need a cooldown as these are our packages
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    # Check the npm registry for updates every day (weekdays)
+    # Check the npm registry for updates every day
     schedule:
-      interval: "monthly"
+      interval: "daily"
     # Make sure we don't just pull in freshly released versions
-    cooldown:
-      default-days: 14
-      exclude:
-        - "myst-cli"
-    groups:
-      npm:
-        patterns: ["*"]
+    allow:
+      - dependency-name: "myst-cli"
     labels:
       - "maintenance"
       - "javascript"


### PR DESCRIPTION
cc @choldgraf - this addresses our conversation in https://github.com/jupyter-book/jupyter-book/issues/2589