### PR TITLE
Docs: patch url for v1 docs (`*/v1` --> `*/v1/intro.html`)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ title: Jupyter Book User Guide
 Jupyter Book is [a distribution of the MyST Document Engine](https://mystmd.org).
 
 :::{seealso} Looking for the Jupyter Book 1 docs?
-This documentation is for Jupyter Book 2. If you're looking for the Jupyter Book 1 docs, go to [jupyterbook.org/v1](https://jupyterbook.org/v1).
+This documentation is for Jupyter Book 2. If you're looking for the Jupyter Book 1 docs, go to https://jupyterbook.org/v1/intro.html.
 :::
 
 ## See `mystmd.org` for more complete documentation

--- a/docs/resources/downgrade.md
+++ b/docs/resources/downgrade.md
@@ -65,8 +65,7 @@ If you need assistance with downgrading or have questions about version compatib
 
 ## Jupyter Book 1 Documentation
 
-The documentation for Jupyter Book 1 is available at:
-[https://jupyterbook.org/v1/](https://jupyterbook.org/v1/)
+The documentation for Jupyter Book 1 is available at: https://jupyterbook.org/v1/intro.html/
 
 ## Considering an Upgrade Again?
 

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -19,7 +19,7 @@ For a detailed comparison, see our [ecosystem documentation](https://jupyterbook
 
 ### Where is the Jupyter Book 1 documentation?
 
-The Jupyter Book 1 documentation is available at [https://jupyterbook.org/v1](https://jupyterbook.org/v1).
+The Jupyter Book 1 documentation is available at https://jupyterbook.org/v1/intro.html.
 
 ### Should I upgrade to Jupyter Book 2 now or wait?
 


### PR DESCRIPTION
**problem**:
The current JB documentation links "v1" docs to the url: https://jupyterbook.org/v1

this url resolves to: https://jupyterbook.org/intro.html

which does not exist ("Page not found")

<details>
  <summary>Screencap📸</summary>

![](https://github.com/user-attachments/assets/0f691040-4feb-4c28-88df-a6ab680faff9)

</details>

**fix**:
patch the links to use the correct, resolving url: https://jupyterbook.org/v1/intro.html

