### PR TITLE
Docs: Separate objective and other hosting options in publishing tutorial

### DIFF
--- a/docs/get-started/publish.md
+++ b/docs/get-started/publish.md
@@ -6,8 +6,12 @@ subject: Quickstart tutorial
 
 :::{important} Objective
 The goal of this tutorial is to publish your Jupyter Book to GitHub Pages so others can read it on the web.
+:::
+
+:::{tip} Not using GitHub?
 For other hosting options (Read the Docs, Netlify, GitLab Pages, Curvenote, custom servers), see the [publishing reference](../build-and-publish/publish.md).
 :::
+
 
 ## GitHub Pages
 


### PR DESCRIPTION
At the #myst-education-2026, GitLab users suggested that the link to the documentation about *other hosting options* was not visible in the *objective* admonition.
Proposing to separate the current admonition into two admonitions, one for the tutorial objective and one for other hosting options. Feel free to change the type of the *other hosting options* admonition or highlight the hosting options in a different way! Thanks! :)